### PR TITLE
[webpack-plugin] use compilation.assets for finding files

### DIFF
--- a/packages/webpack-plugin/index.js
+++ b/packages/webpack-plugin/index.js
@@ -25,18 +25,19 @@ class BuildTrackerPlugin {
   _handleDone(artifacts) {
     const compilation = artifacts.compilation;
 
-    const outputArtifacts = compilation.chunks
-      .map(chunk => {
-        const fileName = chunk.files.filter(fileName => /\.js$/.test(fileName))[0];
+    const outputArtifacts = Object.keys(compilation.assets)
+      .filter(fileName => /\.js$/.test(fileName))
+      .map(fileName => {
         const filePath = path.join(compilation.outputOptions.path, fileName);
+        const fileNameParts = fileName.match(/(.+)\.([a-f0-9]+)\.js$/);
 
         try {
           const file = fs.readFileSync(filePath);
           const gzippedSize = gzip.sync(file);
           return {
-            hash: chunk.hash,
-            name: chunk.name,
-            stat: chunk.size({}),
+            hash: fileNameParts[2],
+            name: fileNameParts[1],
+            stat: file.toString().length,
             gzip: gzippedSize
           };
         } catch (e) {


### PR DESCRIPTION
**Problem:** Some built assets are missing from the webpack plugin output, specifically when using globalize/react-globalize-webpack-plugin

**Solution:** Use webpack's `compilation.assets` to find all of the final asset files instead of relying on the `compilation.chunks`, which may not get updated correctly by various plugins.