### PR TITLE
[builds] add package for working with and pulling data out of 'builds'

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-.*/node_modules/.*
 .*.js.flow
 
 [include]

--- a/flow-typed/build-tracker.js
+++ b/flow-typed/build-tracker.js
@@ -3,10 +3,13 @@
  * Generic Types
  */
 
+declare type BT$BuildMetaItem = string | { value: string, url: string };
+
 declare type BT$BuildMeta = {
-  branch?: string,
-  revision: string,
-  timestamp: number
+  branch?: BT$BuildMetaItem,
+  revision: BT$BuildMetaItem,
+  timestamp: number,
+  [key: string]: BT$BuildMetaItem
 };
 
 declare type BT$Artifact = {

--- a/flow-typed/npm/jest_v21.x.x.js
+++ b/flow-typed/npm/jest_v21.x.x.js
@@ -1,0 +1,541 @@
+// flow-typed signature: 107cf7068b8835594e97f938e8848244
+// flow-typed version: 8b4dd96654/jest_v21.x.x/flow_>=v0.39.x
+
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(fn: (...args: TArguments) => TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(fn: (...args: TArguments) => TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void
+};
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: () => void): void
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(name: string, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void
+};
+declare function fit(name: string, fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(baseName: string, methodNames: Array<string>): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -10,6 +10,7 @@
     "type": "git"
   },
   "dependencies": {
+    "@build-tracker/builds": "^0.0.8",
     "@build-tracker/comparator": "^0.0.7",
     "ascii-table": "^0.0.9",
     "css-loader": "0.28.7",

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -1,6 +1,7 @@
 // @flow
 import BuildFilter from './components/BuildFilter';
 import BuildInfo from './components/BuildInfo';
+import { BuildMeta } from '@build-tracker/builds';
 import Chart from './components/Chart';
 import ComparisonTable from './components/ComparisonTable';
 import deepEqual from 'deep-equal';
@@ -47,7 +48,7 @@ const _getCompareBuilds = (props: { match: Match }, builds: Array<BT$Build>): Ar
     return emptyArray;
   }
 
-  return builds.filter(b => buildRevisions.indexOf(formatSha(b.meta.revision)) !== -1);
+  return builds.filter(b => buildRevisions.indexOf(formatSha(BuildMeta.getRevision(b))) !== -1);
 };
 
 const _getColorScale = (length: number): Function => scaleSequential(interpolateRainbow).domain([0, length]);
@@ -169,7 +170,7 @@ class App extends Component<Props, State> {
                     colorScale={colorScale}
                     onHover={this._handleHover}
                     onSelectBuild={this._handleSelectBuild}
-                    selectedBuilds={compareBuilds.map(b => b.meta.revision)}
+                    selectedBuilds={compareBuilds.map((b: BT$Build) => BuildMeta.getRevision(b))}
                     valueAccessor={valueTypeAccessor[valueType]}
                     xScaleType={xscale}
                     yScaleType={yscale}
@@ -290,7 +291,7 @@ class App extends Component<Props, State> {
   _handleRemoveRevision = (revision: string) => {
     this.setState(
       state => ({
-        compareBuilds: state.compareBuilds.filter(build => build.meta.revision !== revision),
+        compareBuilds: state.compareBuilds.filter(build => BuildMeta.getRevision(build) !== revision),
         selectedBuild: state.compareBuilds.length ? state.compareBuilds[0] : undefined
       }),
       this._updateUrl
@@ -299,7 +300,7 @@ class App extends Component<Props, State> {
 
   _handleShowBuildInfo = (revision: string) => {
     this.setState(state => ({
-      selectedBuild: state.compareBuilds.find(build => build.meta.revision === revision)
+      selectedBuild: state.compareBuilds.find(build => BuildMeta.getRevision(build) === revision)
     }));
   };
 
@@ -311,7 +312,7 @@ class App extends Component<Props, State> {
         ? activeArtifactNames.filter(b => b !== 'All')
         : activeArtifactNames.length === 0 ? ['None'] : activeArtifactNames;
     const safeUrlArtifacts = urlArtifacts.map(name => window.encodeURIComponent(name));
-    const urlRevisions = compareBuilds.map((b: BT$Build) => formatSha(b.meta.revision)).sort();
+    const urlRevisions = compareBuilds.map((b: BT$Build) => formatSha(BuildMeta.getRevision(b))).sort();
     const newPath = `${revisions ? `/revisions/${revisions}` : ''}/${safeUrlArtifacts.join('+')}/${urlRevisions.join(
       '+'
     )}`;

--- a/packages/app/src/api/normalization.js
+++ b/packages/app/src/api/normalization.js
@@ -1,4 +1,5 @@
 // @flow
+import { BuildMeta } from '@build-tracker/builds';
 import { mean } from 'd3-array';
 
 const getAverageSize = (builds: Array<BT$Build>, artifact: string): number =>
@@ -13,4 +14,4 @@ export const getArtifactsByAvgSize = (builds: Array<BT$Build>): Array<string> =>
     .sort((a: string, b: string) => getAverageSize(builds, b) - getAverageSize(builds, a));
 
 export const sortBuilds = (builds: Array<BT$Build>): Array<BT$Build> =>
-  builds.sort((a, b) => new Date(b.meta.timestamp) - new Date(a.meta.timestamp));
+  builds.sort((a, b) => BuildMeta.getDate(b) - BuildMeta.getDate(a));

--- a/packages/app/src/components/BuildInfo.js
+++ b/packages/app/src/components/BuildInfo.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { BuildMeta } from '@build-tracker/builds';
 import theme from '../theme';
 import { formatSha, formatTime } from '../modules/formatting';
 import { StyleSheet, Text, View } from 'react-native';
@@ -11,37 +12,38 @@ type Props = {
 
 export default class BuildInfo extends React.PureComponent<Props> {
   render() {
-    const { build: { meta: { revision, timestamp, ...otherMeta } } } = this.props;
+    const { build } = this.props;
+    const {
+      meta: {
+        branch, // eslint-disable-line
+        revision, // eslint-disable-line
+        timestamp, // eslint-disable-line
+        ...otherMeta
+      }
+    } = build;
     return (
       <View>
-        <Text style={styles.heading}>Build {formatSha(revision)}</Text>
+        <Text style={styles.heading}>Build {formatSha(BuildMeta.getRevision(build))}</Text>
         <Table>
           <Tbody>
             <Tr>
               <Th>Revision</Th>
-              <Td>{revision}</Td>
+              <Td>{BuildMeta.getRevision(build)}</Td>
             </Tr>
             <Tr>
               <Th>Build Time</Th>
-              <Td>{formatTime(timestamp)}</Td>
+              <Td>{formatTime(BuildMeta.getTimestamp(build))}</Td>
             </Tr>
+            {Object.keys(otherMeta).length > 0
+              ? Object.keys(otherMeta).map(key => (
+                  <Tr key={key}>
+                    <Th>{key}</Th>
+                    <Td>{BuildMeta.getMetaValue(otherMeta[key])}</Td>
+                  </Tr>
+                ))
+              : null}
           </Tbody>
         </Table>
-        {Object.keys(otherMeta).length > 0 ? (
-          <View>
-            <Text style={styles.sectionHeading}>Build Meta</Text>
-            <Table>
-              <Tbody>
-                {Object.keys(otherMeta).map(key => (
-                  <Tr>
-                    <Th>{key}</Th>
-                    <Td>{otherMeta[key]}</Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </View>
-        ) : null}
       </View>
     );
   }

--- a/packages/app/src/components/ComparisonTable/ComparisonTable.js
+++ b/packages/app/src/components/ComparisonTable/ComparisonTable.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import ArtifactCell from './ArtifactCell';
+import { BuildMeta } from '@build-tracker/builds';
 import deepEqual from 'deep-equal';
 import DeltaCell from './DeltaCell';
 import { hsl } from 'd3-color';
@@ -19,7 +20,7 @@ const getBodySorter = (artifactNames: Array<string>) => (a: string, b: string): 
   return artifactNames.indexOf(a) - artifactNames.indexOf(b);
 };
 
-const sortBuilds = (a, b) => a.meta.timestamp - b.meta.timestamp;
+const sortBuilds = (a: BT$Build, b: BT$Build) => BuildMeta.getTimestamp(a) - BuildMeta.getTimestamp(b);
 
 type Props = {
   activeArtifactNames: Array<string>,

--- a/packages/builds/.babelrc
+++ b/packages/builds/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "env",
+    "flow"
+  ],
+  "plugins": [
+    "syntax-flow",
+    "transform-object-rest-spread"
+  ]
+}

--- a/packages/builds/README.md
+++ b/packages/builds/README.md
@@ -1,0 +1,7 @@
+# Build Tracker Builds [![npm version](https://img.shields.io/npm/v/@build-tracker/builds.svg?style=flat-square)](https://www.npmjs.com/package/@build-tracker/builds) [![npm downloads](https://img.shields.io/npm/dm/@build-tracker/builds.svg?style=flat-square)](https://www.npmjs.com/package/@build-tracker/builds)
+
+## Install
+
+```
+yarn add @build-tracker/builds
+```

--- a/packages/builds/jest.config.js
+++ b/packages/builds/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  displayName: 'builds',
+  testEnvironment: 'node',
+  rootDir: './',
+  roots: ['<rootDir>/src']
+};

--- a/packages/builds/package.json
+++ b/packages/builds/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@build-tracker/comparator",
-  "version": "0.0.7",
-  "bin": "index.js",
+  "name": "@build-tracker/builds",
+  "version": "0.0.8",
+  "main": "dist",
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "license": "MIT",
   "bugs": {
@@ -11,17 +11,7 @@
     "url": "https://github.com/paularmstrong/build-tracker.git",
     "type": "git"
   },
-  "scripts": {
-    "build": "npm run build:module && npm run build:flow",
-    "build:flow": "flow-copy-source -i __tests__/*.js src dist",
-    "build:module": "babel src --ignore __tests__ -d dist",
-    "test": "jest"
-  },
-  "dependencies": {
-    "@build-tracker/builds": "0.0.8",
-    "ascii-table": "^0.0.9"
-  },
-  "main": "dist",
+  "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -31,5 +21,11 @@
     "babel-watch": "^2.0.7",
     "flow-copy-source": "^1.2.1"
   },
-  "files": ["index.js", "README.md"]
+  "files": ["dist/*", "README.md"],
+  "scripts": {
+    "build": "npm run build:module && npm run build:flow",
+    "build:flow": "flow-copy-source -i __tests__/*.js src dist",
+    "build:module": "babel src -d dist",
+    "test": "jest"
+  }
 }

--- a/packages/builds/src/__tests__/meta.test.js
+++ b/packages/builds/src/__tests__/meta.test.js
@@ -1,0 +1,103 @@
+// @flow
+// eslint-env jest
+import * as BuildMeta from '../meta';
+
+const build = {
+  meta: {
+    timestamp: 12345678,
+    revision: '123456789',
+    branch: 'master',
+    tacos: 'yes please'
+  },
+  artifacts: {}
+};
+
+const buildWithLinks = {
+  ...build,
+  meta: {
+    ...build.meta,
+    revision: { value: '123456789', url: 'https://example.com' },
+    branch: { value: 'master', url: 'https://example.com' },
+    tacos: { value: 'yes please', url: 'https://example.com' }
+  }
+};
+
+describe('BuildMeta', () => {
+  describe('getMetaValue', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getMetaValue(build.meta.tacos)).toBe(build.meta.tacos);
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getMetaValue(buildWithLinks.meta.tacos)).toBe(buildWithLinks.meta.tacos.value);
+    });
+  });
+
+  describe('getMetaUrl', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getMetaUrl(build.meta.tacos)).toBeUndefined();
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getMetaUrl(buildWithLinks.meta.tacos)).toBe(buildWithLinks.meta.tacos.url);
+    });
+  });
+
+  describe('getValue', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getValue(build, 'tacos')).toBe(build.meta.tacos);
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getValue(buildWithLinks, 'tacos')).toBe(buildWithLinks.meta.tacos.value);
+    });
+  });
+
+  describe('getUrl', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getUrl(build, 'tacos')).toBeUndefined();
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getUrl(buildWithLinks, 'tacos')).toBe(buildWithLinks.meta.tacos.url);
+    });
+  });
+
+  describe('getRevision', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getRevision(build)).toBe(build.meta.revision);
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getRevision(buildWithLinks)).toBe(buildWithLinks.meta.revision.value);
+    });
+  });
+
+  describe('getTimestamp', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getTimestamp(build)).toBe(build.meta.timestamp);
+    });
+  });
+
+  describe('getDate', () => {
+    test('gets the date', () => {
+      expect(BuildMeta.getDate(build)).toEqual(new Date(build.meta.timestamp));
+    });
+  });
+
+  describe('getBranch', () => {
+    test('gets the value', () => {
+      expect(BuildMeta.getBranch(build)).toBe(build.meta.branch);
+    });
+
+    test('gets the value when paired with a URL', () => {
+      // $FlowFixMe flow can't figure out
+      expect(BuildMeta.getBranch(buildWithLinks)).toBe(buildWithLinks.meta.branch.value);
+    });
+  });
+});

--- a/packages/builds/src/index.js
+++ b/packages/builds/src/index.js
@@ -1,0 +1,5 @@
+// @flow
+import * as BuildMeta from './meta';
+
+export { BuildMeta };
+export default { BuildMeta };

--- a/packages/builds/src/meta.js
+++ b/packages/builds/src/meta.js
@@ -1,0 +1,35 @@
+// @flow
+
+export const getMetaValue = (metaItem: BT$BuildMetaItem) => {
+  return typeof metaItem === 'object' ? metaItem.value : metaItem;
+};
+
+export const getMetaUrl = (metaItem: BT$BuildMetaItem) => {
+  return typeof metaItem === 'object' ? metaItem.url : undefined;
+};
+
+export const getValue = (build: BT$Build, key: string) => {
+  const metaItem = build.meta[key];
+  return getMetaValue(metaItem);
+};
+
+export const getUrl = (build: BT$Build, key: string) => {
+  const metaItem = build.meta[key];
+  return getMetaUrl(metaItem);
+};
+
+export const getRevision = (build: BT$Build) => {
+  return getValue(build, 'revision');
+};
+
+export const getTimestamp = (build: BT$Build): number => {
+  return build.meta.timestamp;
+};
+
+export const getDate = (build: BT$Build) => {
+  return new Date(getTimestamp(build));
+};
+
+export const getBranch = (build: BT$Build) => {
+  return getValue(build, 'branch');
+};

--- a/packages/comparator/src/index.js
+++ b/packages/comparator/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 import AsciiTable from 'ascii-table';
+import { BuildMeta } from '@build-tracker/builds';
 
 type RevisionStringFormatter = (cell: BT$RevisionCellType) => string;
 type RevisionDeltaStringFormatter = (cell: BT$RevisionDeltaCellType) => string;
@@ -156,8 +157,8 @@ export default class BuildComparator {
       { type: CellType.TEXT, text: '' },
       ...flatten(
         this.buildDeltas.map(buildDelta => {
-          const revision = buildDelta.meta.revision;
-          const revisionIndex = this.builds.findIndex(build => build.meta.revision === revision);
+          const revision = BuildMeta.getRevision(buildDelta);
+          const revisionIndex = this.builds.findIndex(build => BuildMeta.getRevision(build) === revision);
           return [
             { type: CellType.REVISION_HEADER, revision },
             ...buildDelta.artifactDeltas.map((delta, i): BT$RevisionDeltaCellType => {
@@ -165,7 +166,7 @@ export default class BuildComparator {
               return {
                 type: CellType.REVISION_DELTA_HEADER,
                 deltaIndex,
-                againstRevision: this.builds[revisionIndex - deltaIndex - 1].meta.revision,
+                againstRevision: BuildMeta.getRevision(this.builds[revisionIndex - deltaIndex - 1]),
                 revision
               };
             })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,7 +2,6 @@
   "name": "@build-tracker/server",
   "version": "0.0.8",
   "main": "dist",
-  "module": "src",
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "license": "MIT",
   "bugs": {
@@ -14,6 +13,7 @@
   },
   "dependencies": {
     "@build-tracker/app": "^0.0.8",
+    "@build-tracker/builds": "^0.0.8",
     "@build-tracker/comparator": "^0.0.7",
     "body-parser": "^1.18.2",
     "express": "^4.15.4",

--- a/packages/server/src/api/builds.js
+++ b/packages/server/src/api/builds.js
@@ -1,12 +1,13 @@
 // @flow
 import assert from 'assert';
 import BuildComparator from '@build-tracker/comparator';
+import { BuildMeta } from '@build-tracker/builds';
 import type { $Request, $Response } from 'express';
 
-const isValidBuild = (data): void => {
+const isValidBuild = (data: BT$Build): void => {
   assert(data.meta && typeof data.meta === 'object', 'Metadata is provided');
-  assert(data.meta.revision && typeof data.meta.revision === 'string', 'Build revision is provided');
-  assert(data.meta.timestamp && typeof data.meta.timestamp === 'number', 'Build timestamp is provided');
+  assert(BuildMeta.getRevision(data) === 'string', 'Build revision is provided');
+  assert(BuildMeta.getTimestamp(data) === 'number', 'Build timestamp is provided');
   assert(data.artifacts && typeof data.artifacts === 'object', 'Build artifacts are provided');
   Object.keys(data.artifacts).forEach(key => {
     const artifact = data.artifacts[key];
@@ -83,7 +84,7 @@ export const handlePost = ({ getPrevious, insert }: BuildPostOptions, { onBuildI
     .then(() => {
       res.write(JSON.stringify({ success: true }));
     })
-    .then(() => getPrevious(build.meta.timestamp))
+    .then(() => getPrevious(BuildMeta.getTimestamp(build.meta)))
     .then((parentBuild: BT$Build) => {
       const comparator = new BuildComparator([parentBuild, build].filter(Boolean));
       onBuildInserted && onBuildInserted(comparator);

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as Builds from './api/builds';
 import bodyParser from 'body-parser';
+import { BuildMeta } from '@build-tracker/builds';
 import express from 'express';
 import fs from 'fs';
 import glob from 'glob';
@@ -91,8 +92,8 @@ export const staticServer = (options: StaticServerOptions) => {
 
         const builds = matches
           .map(match => require(match))
-          .filter((build: BT$Build) => !branch || build.meta.branch === branch)
-          .sort((a, b) => new Date(b.meta.timestamp) - new Date(a.meta.timestamp))
+          .filter((build: BT$Build) => !branch || BuildMeta.getBranch(build) === branch)
+          .sort((a, b) => BuildMeta.getDate(b) - BuildMeta.getDate(a))
           .slice(0, limit);
         resolve(builds);
       });


### PR DESCRIPTION
**Problem:** It would be beneficial to be able to provide links for keys in the build meta information

**Solution:** Add another package, `@build-tracker/builds` that includes utilities for working with builds. Currently only has methods for extracting meta information, but likely will add more to it.

Updated all references of `build.meta.<key>` to use the new methods available.