### PR TITLE
[app] add table row hovers, fix artifact switch links

### DIFF
--- a/packages/app/src/components/ArtifactSwitch.js
+++ b/packages/app/src/components/ArtifactSwitch.js
@@ -68,7 +68,7 @@ class ArtifactSwitch extends PureComponent<Props> {
     const { params } = match || {};
     const revisionPrefix = params.revisions ? `/revisions/${params.revisions}` : '';
     const compareSuffix = params.compareRevisions ? `/${params.compareRevisions}` : '';
-    return `${revisionPrefix}/${artifactName}${compareSuffix}`;
+    return `${revisionPrefix}/${encodeURIComponent(artifactName)}${compareSuffix}`;
   }
 }
 

--- a/packages/app/src/components/ComparisonTable/RevisionHeaderCell.js
+++ b/packages/app/src/components/ComparisonTable/RevisionHeaderCell.js
@@ -1,5 +1,6 @@
 // @flow
 import { formatSha } from '../../modules/formatting';
+import Hoverable from '../Hoverable';
 import IconX from '../icons/IconX';
 import styles from './styles';
 import { Th } from '../Table';
@@ -16,18 +17,22 @@ export default class RevisionHeaderCell extends PureComponent<Props> {
   render() {
     const { revision } = this.props;
     return (
-      <Th style={[styles.cell, styles.header]} title={revision}>
-        <View style={styles.headerContent}>
-          <Text onClick={this._handleClickInfo} style={styles.headerSha}>
-            {formatSha(revision)}
-          </Text>
-          <View onClick={this._handleClickRemove}>
-            <Text style={[styles.headerButton, styles.removeBuild]}>
-              <IconX />
-            </Text>
-          </View>
-        </View>
-      </Th>
+      <Hoverable>
+        {isHovered => (
+          <Th style={[styles.cell, styles.header]} title={revision}>
+            <View style={styles.headerContent}>
+              <Text onClick={this._handleClickInfo} style={[styles.headerSha, isHovered && styles.headerShaHovered]}>
+                {formatSha(revision)}
+              </Text>
+              <View onClick={this._handleClickRemove}>
+                <Text style={[styles.headerButton, styles.removeBuild]}>
+                  <IconX />
+                </Text>
+              </View>
+            </View>
+          </Th>
+        )}
+      </Hoverable>
     );
   }
 

--- a/packages/app/src/components/ComparisonTable/ValueCell.js
+++ b/packages/app/src/components/ComparisonTable/ValueCell.js
@@ -6,6 +6,8 @@ import { Text } from 'react-native';
 import React, { PureComponent } from 'react';
 
 type Props = {
+  hoverColor: string,
+  isHovered: boolean,
   stat: number,
   gzip: number,
   valueType: 'gzip' | 'stat'
@@ -13,10 +15,10 @@ type Props = {
 
 export default class ValueCell extends PureComponent<Props> {
   render() {
-    const { valueType } = this.props;
+    const { hoverColor, isHovered, valueType } = this.props;
     const value = this.props[valueType];
     return (
-      <Td style={[styles.cell]}>
+      <Td style={[styles.cell, isHovered && { backgroundColor: hoverColor }]}>
         <Text>{value ? bytesToKb(value) : '-'}</Text>
       </Td>
     );

--- a/packages/app/src/components/ComparisonTable/styles.js
+++ b/packages/app/src/components/ComparisonTable/styles.js
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
     left: 'auto',
     zIndex: 2
   },
+
   rowHeader: {
     textAlign: 'left',
     paddingRight: theme.spaceXXSmall
@@ -68,6 +69,9 @@ const styles = StyleSheet.create({
   },
   headerSha: {
     cursor: 'pointer'
+  },
+  headerShaHovered: {
+    color: theme.colorGreen
   },
   headerButton: {
     marginLeft: theme.spaceXSmall,


### PR DESCRIPTION
*Problem:* No hovers on comparison table rows, hard to see what you're looking at
*Solution:* add hovers

*Problem:* ArtifactSwitch links were not encoded, so `i18n/en` breaks URLs when clicking
*Solution:* Use `encodeURIComponent`