### PR TITLE
[all] add packages/types

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@build-tracker/builds": "^0.0.9",
     "@build-tracker/comparator": "^0.0.9",
+    "@build-tracker/types": "^0.0.1",
     "ascii-table": "^0.0.9",
     "css-loader": "0.28.7",
     "d3-array": "^1.2.0",
@@ -45,10 +46,7 @@
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "license": "MIT",
   "proxy": "http://localhost:3000/",
-  "files": [
-    "dist/",
-    "README.md"
-  ],
+  "files": ["dist/", "README.md"],
   "devDependencies": {
     "autoprefixer": "7.1.6",
     "babel-core": "6.26.0",

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -14,6 +14,7 @@ import startOfDay from 'date-fns/start_of_day';
 import subDays from 'date-fns/sub_days';
 import theme from './theme';
 import Toggles from './components/Toggles';
+import type { BT$AppConfig, BT$ArtifactFilters, BT$Build } from '@build-tracker/types';
 import { ChartType, ValueType, valueTypeAccessor, XScaleType, YScaleType } from './modules/values';
 import { interpolateRainbow, scaleSequential } from 'd3-scale';
 import type { Location, Match, RouterHistory } from 'react-router-dom';

--- a/packages/app/src/ContextProvider.js
+++ b/packages/app/src/ContextProvider.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import type { BT$AppConfig } from '@build-tracker/types';
 import merge from 'deepmerge';
 import { object } from 'prop-types';
 

--- a/packages/app/src/api/index.js
+++ b/packages/app/src/api/index.js
@@ -1,4 +1,5 @@
 // @flow
+import type { BT$Build } from '@build-tracker/types';
 import querystring from 'querystring';
 import { getArtifactsByAvgSize, sortBuilds } from './normalization';
 

--- a/packages/app/src/api/normalization.js
+++ b/packages/app/src/api/normalization.js
@@ -1,4 +1,5 @@
 // @flow
+import type { BT$Build } from '@build-tracker/types';
 import { BuildMeta } from '@build-tracker/builds';
 import { mean } from 'd3-array';
 

--- a/packages/app/src/components/BuildFilter/Modal.js
+++ b/packages/app/src/components/BuildFilter/Modal.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import type { BT$ArtifactFilters } from '@build-tracker/types';
 import DateRangePicker from '../DateRangePicker';
 import type { Filters } from './types';
 import ReactDOM from 'react-dom';

--- a/packages/app/src/components/BuildFilter/index.js
+++ b/packages/app/src/components/BuildFilter/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import type { BT$ArtifactFilters } from '@build-tracker/types';
 import type { Filters } from './types';
 import isSameDay from 'date-fns/is_same_day';
 import isToday from 'date-fns/is_today';

--- a/packages/app/src/components/BuildFilter/types.js
+++ b/packages/app/src/components/BuildFilter/types.js
@@ -1,4 +1,6 @@
 // @flow
+import type { BT$ArtifactFilters } from '@build-tracker/types';
+
 export type Filters = {|
   artifactFilters: BT$ArtifactFilters,
   artifactsFiltered: boolean,

--- a/packages/app/src/components/BuildInfo.js
+++ b/packages/app/src/components/BuildInfo.js
@@ -1,4 +1,5 @@
 // @flow
+import type { BT$Build } from '@build-tracker/types';
 import { BuildMeta } from '@build-tracker/builds';
 import Link from './Link';
 import theme from '../theme';

--- a/packages/app/src/components/Chart.js
+++ b/packages/app/src/components/Chart.js
@@ -1,6 +1,7 @@
 // @flow
 import 'd3-transition';
 import * as React from 'react';
+import type { BT$Build } from '@build-tracker/types';
 import { BuildMeta } from '@build-tracker/builds';
 import deepEqual from 'deep-equal';
 import theme from '../theme';

--- a/packages/app/src/components/ComparisonTable/ComparisonTable.js
+++ b/packages/app/src/components/ComparisonTable/ComparisonTable.js
@@ -12,6 +12,14 @@ import RevisionHeaderCell from './RevisionHeaderCell';
 import styles from './styles';
 import theme from '../../theme';
 import ValueCell from './ValueCell';
+import type {
+  BT$AppConfig,
+  BT$BodyCellType,
+  BT$Build,
+  BT$DeltaCellType,
+  BT$HeaderCellType,
+  BT$TotalCellType
+} from '@build-tracker/types';
 import BuildComparator, { CellType } from '@build-tracker/comparator';
 import { Button, Clipboard, View } from 'react-native';
 import { bytesToKb, formatSha } from '../../modules/formatting';

--- a/packages/app/src/modules/values.js
+++ b/packages/app/src/modules/values.js
@@ -1,5 +1,5 @@
 // @flow
-
+import type { BT$Artifact } from '@build-tracker/types';
 type TypesType = { [string]: string };
 
 export const Types: TypesType = {

--- a/packages/builds/package.json
+++ b/packages/builds/package.json
@@ -12,6 +12,7 @@
     "type": "git"
   },
   "devDependencies": {
+    "@build-tracker/types": "^0.0.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-plugin-syntax-flow": "^6.18.0",
@@ -20,10 +21,7 @@
     "babel-watch": "^2.0.7",
     "flow-copy-source": "^1.2.1"
   },
-  "files": [
-    "dist/*",
-    "README.md"
-  ],
+  "files": ["dist/*", "README.md"],
   "scripts": {
     "build": "npm run build:module && npm run build:flow",
     "build:flow": "flow-copy-source -i __tests__/*.js src dist",

--- a/packages/builds/src/meta.js
+++ b/packages/builds/src/meta.js
@@ -1,4 +1,5 @@
 // @flow
+import type { BT$Build, BT$BuildMetaItem } from '@build-tracker/types';
 
 export const getMetaValue = (metaItem: BT$BuildMetaItem) => {
   return typeof metaItem === 'object' ? metaItem.value : metaItem;

--- a/packages/comparator/package.json
+++ b/packages/comparator/package.json
@@ -23,6 +23,7 @@
   },
   "main": "dist",
   "devDependencies": {
+    "@build-tracker/types": "^0.0.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-plugin-syntax-flow": "^6.18.0",
@@ -31,8 +32,5 @@
     "babel-watch": "^2.0.7",
     "flow-copy-source": "^1.2.1"
   },
-  "files": [
-    "index.js",
-    "README.md"
-  ]
+  "files": ["dist/*", "README.md"]
 }

--- a/packages/comparator/src/index.js
+++ b/packages/comparator/src/index.js
@@ -2,6 +2,21 @@
 import AsciiTable from 'ascii-table';
 import { BuildMeta } from '@build-tracker/builds';
 
+import type {
+  BT$Artifact,
+  BT$BodyCellType,
+  BT$Build,
+  BT$BuildDelta,
+  BT$ComparisonMatrix,
+  BT$DeltaCellType,
+  BT$HeaderCellType,
+  BT$RevisionCellType,
+  BT$RevisionDeltaCellType,
+  BT$TextCellType,
+  BT$TotalCellType,
+  BT$TotalDeltaCellType
+} from '@build-tracker/types';
+
 type RevisionStringFormatter = (cell: BT$RevisionCellType) => string;
 type RevisionDeltaStringFormatter = (cell: BT$RevisionDeltaCellType) => string;
 type TotalStringFormatter = (cell: BT$TotalCellType) => string;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,11 +26,9 @@
     "build:module": "babel src --ignore __tests__ -d dist",
     "start:static": "babel-watch -w src testserver.js"
   },
-  "files": [
-    "dist/*",
-    "README.md"
-  ],
+  "files": ["dist/*", "README.md"],
   "devDependencies": {
+    "@build-tracker/builds": "^0.0.9",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-plugin-syntax-flow": "^6.18.0",

--- a/packages/server/src/api/builds.js
+++ b/packages/server/src/api/builds.js
@@ -1,5 +1,6 @@
 // @flow
 import assert from 'assert';
+import type { BT$Build } from '@build-tracker/types';
 import BuildComparator from '@build-tracker/comparator';
 import { BuildMeta } from '@build-tracker/builds';
 import type { $Request, $Response } from 'express';

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -8,6 +8,7 @@ import glob from 'glob';
 import morgan from 'morgan';
 import path from 'path';
 import type { $Request, $Response } from 'express';
+import type { BT$ArtifactFilters, BT$Build, BT$Thresholds } from '@build-tracker/types';
 import type { BuildGetOptions, BuildPostCallbacks, BuildPostOptions, GetBuildsOptions } from './api/builds';
 
 const APP_HTML = require.resolve('@build-tracker/app');

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@build-tracker/types",
+  "version": "0.0.1",
+  "bin": "index.js",
+  "author": "Paul Armstrong <paul@spaceyak.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/paularmstrong/build-tracker/issues"
+  },
+  "repository": {
+    "url": "https://github.com/paularmstrong/build-tracker.git",
+    "type": "git"
+  },
+  "scripts": {},
+  "dependencies": {},
+  "main": "src",
+  "devDependencies": {},
+  "files": ["src/", "README.md"]
+}

--- a/packages/types/src/index.js
+++ b/packages/types/src/index.js
@@ -1,25 +1,26 @@
 // @flow
+
 /**
  * Generic Types
  */
 
-declare type BT$BuildMetaItem = string | { value: string, url: string };
+export type BT$BuildMetaItem = string | { value: string, url: string };
 
-declare type BT$BuildMeta = {
+export type BT$BuildMeta = {
   branch?: BT$BuildMetaItem,
   revision: BT$BuildMetaItem,
   timestamp: number,
   [key: string]: BT$BuildMetaItem
 };
 
-declare type BT$Artifact = {
+export type BT$Artifact = {
   hash: string,
   name: string,
   stat: number,
   gzip: number
 };
 
-declare type BT$Build = {|
+export type BT$Build = {|
   meta: BT$BuildMeta,
   artifacts: { [name: string]: BT$Artifact }
 |};
@@ -28,17 +29,18 @@ declare type BT$Build = {|
  * Comparison Matrix
  */
 
-declare type BT$BuildDelta = {|
+export type BT$BuildDelta = {|
   meta: BT$BuildMeta,
   artifactDeltas: Array<{ [name: string]: BT$DeltaCellType }>,
   deltas: Array<BT$TotalDeltaCellType>
 |};
-declare type BT$TextCellType = {|
+
+export type BT$TextCellType = {|
   type: 'text',
   text: string
 |};
 
-declare type BT$DeltaCellType = {|
+export type BT$DeltaCellType = {|
   type: 'delta',
   stat: number,
   statPercent: number,
@@ -47,13 +49,13 @@ declare type BT$DeltaCellType = {|
   hashChanged: boolean
 |};
 
-declare type BT$TotalCellType = {|
+export type BT$TotalCellType = {|
   type: 'total',
   stat: number,
   gzip: number
 |};
 
-declare type BT$TotalDeltaCellType = {|
+export type BT$TotalDeltaCellType = {|
   type: 'totalDelta',
   stat: number,
   statPercent: number,
@@ -61,27 +63,27 @@ declare type BT$TotalDeltaCellType = {|
   gzipPercent: number
 |};
 
-declare type BT$RevisionCellType = {|
+export type BT$RevisionCellType = {|
   type: 'revision',
   revision: string
 |};
 
-declare type BT$RevisionDeltaCellType = {|
+export type BT$RevisionDeltaCellType = {|
   type: 'revisionDelta',
   revision: string,
   deltaIndex: number,
   againstRevision: string
 |};
 
-declare type BT$ArtifactCellType = {|
+export type BT$ArtifactCellType = {|
   type: 'artifact',
   text: string
 |};
 
-declare type BT$BodyCellType = BT$ArtifactCellType | BT$DeltaCellType | BT$TotalCellType;
-declare type BT$HeaderCellType = BT$TextCellType | BT$RevisionCellType | BT$RevisionDeltaCellType;
+export type BT$BodyCellType = BT$ArtifactCellType | BT$DeltaCellType | BT$TotalCellType;
+export type BT$HeaderCellType = BT$TextCellType | BT$RevisionCellType | BT$RevisionDeltaCellType;
 
-declare type BT$ComparisonMatrix = {
+export type BT$ComparisonMatrix = {
   header: Array<BT$HeaderCellType>,
   total: Array<BT$BodyCellType>,
   body: Array<Array<BT$BodyCellType>>
@@ -91,16 +93,16 @@ declare type BT$ComparisonMatrix = {
  * Application
  */
 
-declare type BT$Thresholds = {|
+export type BT$Thresholds = {|
   stat?: number,
   statPercent?: number,
   gzip?: number,
   gzipPercent?: number
 |};
 
-declare type BT$ArtifactFilters = Array<RegExp>;
+export type BT$ArtifactFilters = Array<RegExp>;
 
-declare type BT$AppConfig = {|
+export type BT$AppConfig = {|
   artifactFilters?: BT$ArtifactFilters,
   thresholds?: BT$Thresholds
 |};


### PR DESCRIPTION
**Problem:** Using global types in `./flow-typed/build-tracker.js` reduces the ability to properly check types in projects that depend on any of the build-tracker packages.

**Solution:** Add a new package, `@build-tracker/types` that exports these shared types.