### PR TITLE
[comparator] fix getSum filter to be more strict

### DIFF
--- a/packages/comparator/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/comparator/src/__tests__/__snapshots__/index.test.js.snap
@@ -137,15 +137,15 @@ Array [
     "type": "total",
   },
   Object {
-    "gzip": 45,
-    "stat": 123,
+    "gzip": 138,
+    "stat": 592,
     "type": "total",
   },
   Object {
-    "gzip": -90,
-    "gzipPercent": 0.3333333333333333,
-    "stat": -456,
-    "statPercent": 0.21243523316062177,
+    "gzip": 3,
+    "gzipPercent": 1.0222222222222221,
+    "stat": 13,
+    "statPercent": 1.0224525043177892,
     "type": "totalDelta",
   },
 ]

--- a/packages/comparator/src/index.js
+++ b/packages/comparator/src/index.js
@@ -253,7 +253,7 @@ export default class BuildComparator {
   }
 
   getSum(artifactNames: Array<string>): Array<BT$BodyCellType> {
-    const filters = [new RegExp(`^(?!${artifactNames.join('|')})`)];
+    const filters = [new RegExp(`^(?!${artifactNames.join('|')})$`)];
     return [
       { type: CellType.TEXT, text: 'Sum' },
       ...flatten(


### PR DESCRIPTION
**Problem:** the `comparator.getSum` function was returning higher results than should be expected.

**Solution:** Fix the filter regex to be more strict.