### PR TITLE
Next size keys

### DIFF
--- a/src/app/src/components/ColorScalePicker/ColorScale.tsx
+++ b/src/app/src/components/ColorScalePicker/ColorScale.tsx
@@ -18,9 +18,9 @@ export const ColorScale = (props: Props): React.ReactElement => {
   const { boxes, isSelected, name, onSelect, scale, style } = props;
 
   const colorScale = scale.domain([0, boxes]);
-  const handlePress = (): void => {
+  const handlePress = React.useCallback((): void => {
     onSelect(scale);
-  };
+  }, [onSelect, scale]);
 
   return (
     <Hoverable>

--- a/src/app/src/components/Drawer.tsx
+++ b/src/app/src/components/Drawer.tsx
@@ -22,7 +22,7 @@ class Drawer extends React.Component<Props, State> {
   public shouldComponentUpdate(_: Props, prevState: State): boolean {
     const { hidden } = this.props;
     const { forceShow } = this.state;
-    return !hidden || forceShow !== prevState.forceShow;
+    return !hidden || forceShow || forceShow !== prevState.forceShow;
   }
 
   // TODO: on route change, hide the drawer

--- a/src/app/src/components/Graph/Area.tsx
+++ b/src/app/src/components/Graph/Area.tsx
@@ -25,10 +25,6 @@ const Area = (props: Props): React.ReactElement => {
   }, [colorScale, comparator.artifactNames]);
 
   React.useEffect(() => {
-    if (!gRef.current) {
-      return;
-    }
-
     const dataStack = stack();
     dataStack.keys(activeArtifactNames);
     // @ts-ignore
@@ -67,7 +63,7 @@ const Area = (props: Props): React.ReactElement => {
       .attr('d', areaChart);
   });
 
-  return <g ref={gRef} />;
+  return <g aria-label={`Stacked area chart for ${activeArtifactNames.join(', ')}`} ref={gRef} />;
 };
 
 export default Area;

--- a/src/app/src/components/Graph/__tests__/Area.test.tsx
+++ b/src/app/src/components/Graph/__tests__/Area.test.tsx
@@ -1,0 +1,81 @@
+import Area from '../Area';
+import Build from '@build-tracker/build';
+import ColorScale from '../../../modules/ColorScale';
+import Comparator from '@build-tracker/comparator';
+import React from 'react';
+import { render } from 'react-testing-library';
+import { timerFlush } from 'd3-timer';
+import { scaleLinear, scalePoint } from 'd3-scale';
+
+describe('Area', () => {
+  test('only draws the active artifacts', () => {
+    const builds = [
+      new Build({ revision: '123', parentRevision: '000', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { gzip: 123 } },
+        { name: 'vendor', hash: '123', sizes: { gzip: 123 } }
+      ]),
+      new Build({ revision: 'abc', parentRevision: '123', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { gzip: 123 } },
+        { name: 'vendor', hash: '123', sizes: { gzip: 123 } }
+      ])
+    ];
+    const comparator = new Comparator({ builds });
+    const xScale = scalePoint()
+      .range([0, 100])
+      .domain(['123', 'abc']);
+    const yScale = scaleLinear()
+      .range([400, 0])
+      .domain([0, 400]);
+    const { getByLabelText } = render(
+      <svg>
+        <Area
+          activeArtifactNames={['main']}
+          colorScale={ColorScale.Rainbow}
+          comparator={comparator}
+          sizeKey="gzip"
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </svg>
+    );
+    timerFlush();
+    const wrapper = getByLabelText('Stacked area chart for main');
+    expect(wrapper.children).toHaveLength(1);
+  });
+
+  test('can render if an artifact does not exist in a build', () => {
+    const builds = [
+      new Build({ revision: '123', parentRevision: '000', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 456 } }
+      ]),
+      new Build({ revision: 'abc', parentRevision: '123', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 489 } },
+        { name: 'vendor', hash: '123', sizes: { stat: 123 } }
+      ])
+    ];
+    const comparator = new Comparator({ builds });
+    const xScale = scalePoint()
+      .range([0, 100])
+      .domain(['123', 'abc']);
+    const yScale = scaleLinear()
+      .range([400, 0])
+      .domain([0, 400]);
+    const { getByLabelText } = render(
+      <svg>
+        <Area
+          activeArtifactNames={['main', 'vendor']}
+          colorScale={ColorScale.Rainbow}
+          comparator={comparator}
+          sizeKey="stat"
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </svg>
+    );
+    timerFlush();
+    const wrapper = getByLabelText('Stacked area chart for main, vendor');
+    expect(wrapper.children).toHaveLength(2);
+    expect(wrapper.children[0].nodeName).toEqual('path');
+    expect(wrapper.children[1].nodeName).toEqual('path');
+  });
+});

--- a/src/app/src/components/SizeKeyPicker/SizeKeyButton.tsx
+++ b/src/app/src/components/SizeKeyPicker/SizeKeyButton.tsx
@@ -1,0 +1,32 @@
+import Button from '../Button';
+import React from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+
+interface Props {
+  isSelected?: boolean;
+  onSelect: (value: string) => void;
+  style?: StyleProp<ViewStyle>;
+  value: string;
+}
+
+const SizeKeyPicker = (props: Props): React.ReactElement => {
+  const { isSelected, onSelect, style, value } = props;
+
+  const handleSelect = React.useCallback(() => {
+    onSelect(value);
+  }, [onSelect, value]);
+
+  return (
+    <Button
+      aria-selected={isSelected}
+      color={isSelected ? 'primary' : 'secondary'}
+      disabled={isSelected}
+      onPress={handleSelect}
+      style={style}
+      title={value}
+      type="unelevated"
+    />
+  );
+};
+
+export default SizeKeyPicker;

--- a/src/app/src/components/SizeKeyPicker/__tests__/SizeKeyButton.test.tsx
+++ b/src/app/src/components/SizeKeyPicker/__tests__/SizeKeyButton.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import SizeKeyButton from '../SizeKeyButton';
+import { fireEvent, render } from 'react-native-testing-library';
+
+describe('SizeKeyButton', () => {
+  describe('isSelected', () => {
+    test('sets aria-selected when tru', () => {
+      const { getByProps } = render(<SizeKeyButton isSelected onSelect={jest.fn()} value="tacos" />);
+      expect(getByProps({ title: 'tacos' }).props['aria-selected']).toBe(true);
+    });
+
+    test('disables the button when true', () => {
+      const { getByProps } = render(<SizeKeyButton isSelected onSelect={jest.fn()} value="tacos" />);
+      expect(getByProps({ title: 'tacos' }).props.disabled).toBe(true);
+    });
+
+    test('does not set aria-selected when false', () => {
+      const { getByProps } = render(<SizeKeyButton onSelect={jest.fn()} value="tacos" />);
+      expect(getByProps({ title: 'tacos' }).props['aria-selected']).toBeUndefined();
+    });
+
+    test('is not disabled when false', () => {
+      const { getByProps } = render(<SizeKeyButton onSelect={jest.fn()} value="tacos" />);
+      expect(getByProps({ title: 'tacos' }).props.disabled).toBe(false);
+    });
+  });
+
+  describe('onSelect', () => {
+    test('fires onSelect with the value', () => {
+      const handleOnSelect = jest.fn();
+      const { getByProps } = render(<SizeKeyButton onSelect={handleOnSelect} value="tacos" />);
+      fireEvent.press(getByProps({ title: 'tacos' }));
+      expect(handleOnSelect).toHaveBeenCalledWith('tacos');
+    });
+  });
+});

--- a/src/app/src/components/SizeKeyPicker/__tests__/index.test.tsx
+++ b/src/app/src/components/SizeKeyPicker/__tests__/index.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import SizeKeyPicker from '../';
+import { fireEvent, render } from 'react-native-testing-library';
+
+describe('SizeKeyPicker', () => {
+  test('renders a button per key', () => {
+    const { queryAllByProps } = render(<SizeKeyPicker keys={['foo', 'bar']} onSelect={jest.fn()} selected="foo" />);
+    expect(queryAllByProps({ isSelected: true, value: 'foo' })).toHaveLength(1);
+    expect(queryAllByProps({ isSelected: false, value: 'bar' })).toHaveLength(1);
+  });
+
+  test('passes the onSelect handler', () => {
+    const handleSelect = jest.fn();
+    const { queryAllByProps } = render(
+      <SizeKeyPicker keys={['foo', 'bar', 'tacos']} onSelect={handleSelect} selected="foo" />
+    );
+    const buttons = queryAllByProps({ onSelect: handleSelect });
+    expect(buttons).toHaveLength(4); // the root component counts as 1
+    fireEvent(buttons[0], 'select', 'foo');
+    expect(handleSelect).toHaveBeenCalledWith('foo');
+  });
+});

--- a/src/app/src/components/SizeKeyPicker/index.tsx
+++ b/src/app/src/components/SizeKeyPicker/index.tsx
@@ -1,0 +1,34 @@
+import * as Theme from '../../theme';
+import React from 'react';
+import SizeKeyButton from './SizeKeyButton';
+import { StyleSheet, View } from 'react-native';
+
+interface Props {
+  keys: Array<string>;
+  onSelect: (key: string) => void;
+  selected: string;
+}
+
+const SizeKeyPicker = (props: Props): React.ReactElement => {
+  const { keys, onSelect, selected } = props;
+  return (
+    <View style={styles.root}>
+      {keys.map(key => (
+        <SizeKeyButton isSelected={selected === key} key={key} onSelect={onSelect} style={styles.button} value={key} />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    marginHorizontal: Theme.Spacing.Normal,
+    marginBottom: Theme.Spacing.Normal
+  },
+  button: {
+    marginEnd: Theme.Spacing.Normal
+  }
+});
+
+export default SizeKeyPicker;

--- a/src/app/src/screens/Main.tsx
+++ b/src/app/src/screens/Main.tsx
@@ -13,6 +13,7 @@ import Graph from '../components/Graph';
 import MenuIcon from '../icons/Menu';
 import React from 'react';
 import { ScaleSequential } from 'd3-scale';
+import SizeKeyPicker from '../components/SizeKeyPicker';
 import Subtitle from '../components/Subtitle';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
@@ -27,6 +28,7 @@ const Main = (): React.ReactElement => {
   const comparator = React.useMemo((): Comparator => new Comparator({ builds }), []);
 
   const [colorScale, setColorScale] = React.useState<ScaleSequential<string>>(() => ColorScale.Rainbow);
+  const [sizeKey, setSizeKey] = React.useState<string>(comparator.sizeKeys[0]);
   const [activeArtifacts, setActiveArtifacts] = React.useState<{ [key: string]: boolean }>(
     comparator.artifactNames.reduce((memo: { [key: string]: boolean }, name: string) => {
       memo[name] = true;
@@ -73,10 +75,20 @@ const Main = (): React.ReactElement => {
     [activeArtifacts]
   );
 
+  const handleSelectSizeKey = React.useCallback(
+    (name: string): void => {
+      setSizeKey(name);
+      forceUpdate(Date.now());
+    },
+    [setSizeKey]
+  );
+
   return (
     <View style={styles.layout}>
       <Drawer hidden ref={drawerRef}>
-        <Subtitle title="Color Scale" />
+        <Subtitle title="Compare artifacts by" />
+        <SizeKeyPicker keys={comparator.sizeKeys} onSelect={handleSelectSizeKey} selected={sizeKey} />
+        <Subtitle title="Color scale" />
         <ColorScalePicker activeColorScale={colorScale} onSelect={handleSelectColorScale} />
       </Drawer>
       <View
@@ -86,7 +98,7 @@ const Main = (): React.ReactElement => {
       >
         <View style={[styles.column, styles.chart]}>
           <AppBar navigationIcon={MenuIcon} onPressNavigationIcon={showDrawer} title="Build Tracker" />
-          <Graph activeArtifacts={activeArtifacts} colorScale={colorScale} comparator={comparator} sizeKey="gzip" />
+          <Graph activeArtifacts={activeArtifacts} colorScale={colorScale} comparator={comparator} sizeKey={sizeKey} />
         </View>
         <View key="table" style={[styles.column, styles.table]}>
           <ScrollView horizontal style={styles.tableScroll}>
@@ -97,7 +109,7 @@ const Main = (): React.ReactElement => {
                 comparator={comparator}
                 onDisableArtifact={handleDisableArtifact}
                 onEnableArtifact={handleEnableArtifact}
-                sizeKey="gzip"
+                sizeKey={sizeKey}
               />
             </ScrollView>
           </ScrollView>

--- a/src/comparator/src/__tests__/index.test.ts
+++ b/src/comparator/src/__tests__/index.test.ts
@@ -56,6 +56,20 @@ describe('BuildComparator', () => {
     });
   });
 
+  describe('sizeKeys', () => {
+    test('gets a list of size keys available', () => {
+      const comparator = new BuildComparator({ builds: [build1, build2] });
+      expect(comparator.sizeKeys).toEqual(['stat', 'gzip']);
+    });
+
+    test('throws an error if some builds have size keys that others do not', () => {
+      const comparator = new BuildComparator({
+        builds: [new Build(build1.meta, [{ name: 'tacos', hash: 'abc', sizes: { tacos: 123 } }]), build2]
+      });
+      expect(() => comparator.sizeKeys).toThrow();
+    });
+  });
+
   describe('buildDeltas', () => {
     test('are cached across gets', () => {
       const comparator = new BuildComparator({ builds: [build1, build2] });

--- a/src/comparator/src/__tests__/index.test.ts
+++ b/src/comparator/src/__tests__/index.test.ts
@@ -59,7 +59,7 @@ describe('BuildComparator', () => {
   describe('sizeKeys', () => {
     test('gets a list of size keys available', () => {
       const comparator = new BuildComparator({ builds: [build1, build2] });
-      expect(comparator.sizeKeys).toEqual(['stat', 'gzip']);
+      expect(comparator.sizeKeys).toEqual(['gzip', 'stat']);
     });
 
     test('throws an error if some builds have size keys that others do not', () => {

--- a/src/comparator/src/index.ts
+++ b/src/comparator/src/index.ts
@@ -168,7 +168,7 @@ export default class BuildComparator {
 
   public get sizeKeys(): Array<string> {
     if (!this._sizeKeys) {
-      this._sizeKeys = Object.keys(this.builds[0].artifacts[0].sizes);
+      this._sizeKeys = Object.keys(this.builds[0].artifacts[0].sizes).sort();
       const allSizeKeys = new Set();
       this.builds.forEach(build => {
         build.artifacts.forEach(artifact => {

--- a/src/comparator/src/index.ts
+++ b/src/comparator/src/index.ts
@@ -137,6 +137,7 @@ export default class BuildComparator {
 
   private _artifactFilters: ArtifactFilters;
   private _artifactNames: Array<string>;
+  private _sizeKeys: Array<string>;
   private _buildDeltas: Array<Array<BuildDelta>>;
 
   private _matrixHeader: Array<HeaderCell>;
@@ -163,6 +164,25 @@ export default class BuildComparator {
         );
     }
     return this._artifactNames;
+  }
+
+  public get sizeKeys(): Array<string> {
+    if (!this._sizeKeys) {
+      this._sizeKeys = Object.keys(this.builds[0].artifacts[0].sizes);
+      const allSizeKeys = new Set();
+      this.builds.forEach(build => {
+        build.artifacts.forEach(artifact => {
+          Object.keys(artifact.sizes).forEach(key => {
+            allSizeKeys.add(key);
+          });
+        });
+      });
+
+      if (allSizeKeys.size !== this._sizeKeys.length) {
+        throw new Error();
+      }
+    }
+    return this._sizeKeys;
   }
 
   public get buildDeltas(): Array<Array<BuildDelta>> {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Unable to change the artifact size key used in the graph and table.

Fixes #29 

# Solution

* Add `.sizeKeys` getter to comparator. Memoized and throws if some builds are missing keys (not sure if this is best long-term)
* Adds a sizeKeyPicker to the app drawer
* State managed by Main

# TODO

- [X] 🤓 Add & update tests (always try to _increase_ test coverage)
- [X] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
