### PR TITLE
@build-tracker/plugin-with-postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 dist
 .eslintcache
 coverage
+.env

--- a/config/fixtures.js
+++ b/config/fixtures.js
@@ -42,5 +42,6 @@ module.exports = {
       }
     }
   },
-  setup: () => Promise.resolve()
+  setup: () => Promise.resolve(),
+  url: 'http://localhost:3000'
 };

--- a/config/postgres.js
+++ b/config/postgres.js
@@ -1,0 +1,8 @@
+const withPostgres = require('@build-tracker/plugin-with-postgres').default;
+
+module.exports = withPostgres({
+  dev: true,
+  pg: {
+    ssl: true
+  }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/app/src/icons/**/*.{ts,tsx}'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', 'plugins/**/*.{ts,tsx}', '!src/app/src/icons/**/*.{ts,tsx}'],
   projects: ['<rootDir>/src/*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testPathIgnorePatterns: ['node_modules'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', 'plugins/**/*.{ts,tsx}', '!src/app/src/icons/**/*.{ts,tsx}'],
-  projects: ['<rootDir>/src/*'],
+  projects: ['<rootDir>/src/*', '<rootDir>/plugins/*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   testPathIgnorePatterns: ['node_modules'],
   modulePathIgnorePatterns: ['dist', 'lib']

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,5 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "0.0.0",
-  "packages": [
-    "src/*"
-  ]
+  "packages": ["src/*", "plugins/*"]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "src/*"
+    "src/*",
+    "plugins/*"
   ],
   "scripts": {
     "dev": "ts-node src/server/src/index.ts run -c ./src/app/config/devserver.config.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "plugins/*"
   ],
   "scripts": {
-    "dev": "ts-node src/server/src/index.ts run -c ./src/app/config/devserver.config.js",
+    "dev": "ts-node src/server/src/index.ts run -c ./config/fixtures.js",
     "prebuild": "yarnpkg clean",
     "build": "lerna run build --stream --parallel",
     "clean": "lerna run clean --stream --parallel",

--- a/plugins/.eslintrc.js
+++ b/plugins/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   plugins: ['header'],
   rules: {
     'header/header': ['error', path.join(__dirname, '../config/copyright.txt')]
-  }
+  },
+  overrides: [{ files: '*.md', rules: { 'header/header': 'off' } }]
 };

--- a/plugins/.eslintrc.js
+++ b/plugins/.eslintrc.js
@@ -1,0 +1,7 @@
+const path = require('path');
+module.exports = {
+  plugins: ['header'],
+  rules: {
+    'header/header': ['error', path.join(__dirname, '../config/copyright.txt')]
+  }
+};

--- a/plugins/with-postgres/README.md
+++ b/plugins/with-postgres/README.md
@@ -1,0 +1,48 @@
+# @build-tracker/plugin-with-postgres
+
+A server-configuration plugin for Build Tracker to enable reading build data from a Postgres database.
+
+Wrap your server's `build-tracker.config.js` configuration with `withPostgres` and include the `pg` options object:
+
+```js
+const withPostgres = require('@build-tracker/plugin-with-postgres');
+
+module.exports = withPostgres({
+  pg: {
+    user: '', // default: process.env.PGUSER
+    host: '', // default: process.env.PGHOST
+    database: '', // default: process.env.PGPASSWORD
+    password: '', // default: process.env.PGDATABASE
+    port: 5432, // default: process.env.PGPORT
+    ssl: true
+  }
+});
+```
+
+## Configuration
+
+All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
+
+### `host: string = process.env.PGHOST`
+
+Database host.
+
+### `database: string = process.env.PGPASSWORD`
+
+Database name.
+
+### `user: string = process.env.PGUSER`
+
+Database username with read access.
+
+### `password: string = process.env.PGDATABASE`
+
+Password for the given database username.
+
+### `port: number = process.env.PGPORT = 5432`
+
+Database host port.
+
+### `ssl: boolean = false`
+
+Set to true to connect to your host using SSL (if supported).

--- a/plugins/with-postgres/jest.config.js
+++ b/plugins/with-postgres/jest.config.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+module.exports = {
+  displayName: 'with-postgres',
+  testEnvironment: 'node',
+  resetMocks: true,
+  rootDir: './',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  }
+};

--- a/plugins/with-postgres/package.json
+++ b/plugins/with-postgres/package.json
@@ -13,10 +13,13 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
+    "@build-tracker/api-errors": "1.0.0",
+    "dotenv": "^7.0.0",
     "pg": "^7.8.2"
   },
   "devDependencies": {
     "@build-tracker/types": "1.0.0",
+    "@types/dotenv": "^6.1.0",
     "@types/pg": "^7.4.13"
   }
 }

--- a/plugins/with-postgres/package.json
+++ b/plugins/with-postgres/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@build-tracker/plugin-with-postgres",
+  "version": "1.0.0",
+  "description": "Build Tracker server plugin for PostgreSQL",
+  "author": "Paul Armstrong <paul@spaceyak.com>",
+  "repository": "git@github.com:paularmstrong/build-tracker.git",
+  "license": "MIT",
+  "main": "dist",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "pg": "^7.8.2"
+  },
+  "devDependencies": {
+    "@build-tracker/types": "1.0.0",
+    "@types/pg": "^7.4.13"
+  }
+}

--- a/plugins/with-postgres/src/__tests__/index.test.ts
+++ b/plugins/with-postgres/src/__tests__/index.test.ts
@@ -6,6 +6,8 @@ import withPostgres from '../';
 
 jest.mock('pg');
 
+const url = 'https://build-tracker.local';
+
 describe('withPostgres', () => {
   beforeAll(() => {
     // @ts-ignore
@@ -15,15 +17,15 @@ describe('withPostgres', () => {
   });
 
   test('preserves user-set config', () => {
-    expect(withPostgres({ pg: {}, port: 1234 })).toMatchObject({ port: 1234 });
+    expect(withPostgres({ pg: {}, port: 1234, url })).toMatchObject({ port: 1234 });
   });
 
   test('adds setup', () => {
-    expect(withPostgres({ pg: {} })).toHaveProperty('setup');
+    expect(withPostgres({ pg: {}, url })).toHaveProperty('setup');
   });
 
   test('adds queries', () => {
-    expect(withPostgres({ pg: {} })).toMatchObject({
+    expect(withPostgres({ pg: {}, url })).toMatchObject({
       queries: {
         build: {
           byRevision: expect.any(Function),

--- a/plugins/with-postgres/src/__tests__/index.test.ts
+++ b/plugins/with-postgres/src/__tests__/index.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'pg';
+import withPostgres from '../';
+
+jest.mock('pg');
+
+describe('withPostgres', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    Pool.mockImplementation(() => {
+      return {};
+    });
+  });
+
+  test('preserves user-set config', () => {
+    expect(withPostgres({ pg: {}, port: 1234 })).toMatchObject({ port: 1234 });
+  });
+
+  test('adds setup', () => {
+    expect(withPostgres({ pg: {} })).toHaveProperty('setup');
+  });
+
+  test('adds queries', () => {
+    expect(withPostgres({ pg: {} })).toMatchObject({
+      queries: {
+        build: {
+          byRevision: expect.any(Function),
+          insert: expect.any(Function)
+        },
+        builds: {
+          byRevisions: expect.any(Function),
+          byRevisionRange: expect.any(Function),
+          byTimeRange: expect.any(Function)
+        }
+      }
+    });
+  });
+});

--- a/plugins/with-postgres/src/__tests__/queries.test.ts
+++ b/plugins/with-postgres/src/__tests__/queries.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'pg';
+import Queries from '../queries';
+
+jest.mock('pg');
+
+describe('withPostgres', () => {
+  let query;
+  beforeEach(() => {
+    query = jest.fn();
+    // @ts-ignore
+    Pool.mockImplementation(() => ({ query }));
+  });
+
+  describe('getByRevision', () => {
+    test('selects meta and artifacts', () => {
+      const row = { meta: {}, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [row] }));
+      const queries = new Queries(new Pool());
+      return queries.getByRevision('12345').then(res => {
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision = $1', ['12345']);
+        expect(res).toEqual(row);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(new Pool());
+      return queries.getByRevision('12345').catch(err => {
+        expect(err.message).toEqual('No result found');
+      });
+    });
+  });
+
+  describe('insert', () => {
+    test('returns the revision on insert', () => {
+      const queries = new Queries(new Pool());
+      const now = Date.now();
+      const build = {
+        meta: {
+          revision: { value: '12345', url: 'https://build-tracker.local' },
+          timestamp: now,
+          parentRevision: 'abcdef'
+        },
+        artifacts: []
+      };
+      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [build] }));
+      return queries.insert(build).then(res => {
+        expect(query).toHaveBeenCalledWith(
+          'INSERT INTO builds (revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, @4)',
+          ['12345', now, 'abcdef', build.meta, build.artifacts]
+        );
+        expect(res).toEqual('12345');
+      });
+    });
+
+    test('rejects if rowCount is not 1', () => {
+      const queries = new Queries(new Pool());
+      const now = Date.now();
+      const build = {
+        meta: {
+          revision: 'abcdef',
+          timestamp: now,
+          parentRevision: '12345'
+        },
+        artifacts: []
+      };
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      return queries.insert(build).catch(err => {
+        expect(err.message).toEqual('Unable to insert build');
+      });
+    });
+  });
+
+  describe('getByRevisions', () => {
+    test('selects meta and artifacts', () => {
+      const row1 = { meta: { revision: '12345' }, artifacts: [] };
+      const row2 = { meta: { revision: 'abcde' }, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      const queries = new Queries(new Pool());
+      return queries.getByRevisions('12345', 'abcde').then(res => {
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in $1', [
+          ['12345', 'abcde']
+        ]);
+        expect(res).toEqual([row1, row2]);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(new Pool());
+      return queries.getByRevisions('12345', 'abcde').catch(err => {
+        expect(err.message).toEqual('No result found');
+      });
+    });
+  });
+
+  describe('getByRevisionRange', () => {
+    test('throw unimplemented error', () => {
+      const queries = new Queries(new Pool());
+      return queries.getByRevisionRange('12345', 'abcde').catch(err => {
+        expect(err.message).toMatch('unimplemented');
+      });
+    });
+  });
+
+  describe('getByTimeRange', () => {
+    test('selects meta and artifacts', () => {
+      const row1 = { meta: { revision: '12345' }, artifacts: [] };
+      const row2 = { meta: { revision: 'abcde' }, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      const queries = new Queries(new Pool());
+      return queries.getByTimeRange(12345, 67890).then(res => {
+        expect(query).toHaveBeenCalledWith(
+          'SELECT meta, artifacts FROM builds WHERE  timestamp >= $1 AND timestamp <= $2 ORDER BY timestamp',
+          [12345, 67890]
+        );
+        expect(res).toEqual([row1, row2]);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(new Pool());
+      return queries.getByTimeRange(12345, 67890).catch(err => {
+        expect(err.message).toEqual('No result found');
+      });
+    });
+  });
+});

--- a/plugins/with-postgres/src/__tests__/queries.test.ts
+++ b/plugins/with-postgres/src/__tests__/queries.test.ts
@@ -3,6 +3,7 @@
  */
 import { Pool } from 'pg';
 import Queries from '../queries';
+import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
 
 jest.mock('pg');
 
@@ -29,7 +30,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
       const queries = new Queries(new Pool());
       return queries.getByRevision('12345').catch(err => {
-        expect(err.message).toEqual('No result found');
+        expect(err).toBeInstanceOf(NotFoundError);
       });
     });
   });
@@ -92,7 +93,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
       const queries = new Queries(new Pool());
       return queries.getByRevisions('12345', 'abcde').catch(err => {
-        expect(err.message).toEqual('No result found');
+        expect(err).toBeInstanceOf(NotFoundError);
       });
     });
   });
@@ -101,7 +102,7 @@ describe('withPostgres', () => {
     test('throw unimplemented error', () => {
       const queries = new Queries(new Pool());
       return queries.getByRevisionRange('12345', 'abcde').catch(err => {
-        expect(err.message).toMatch('unimplemented');
+        expect(err).toBeInstanceOf(UnimplementedError);
       });
     });
   });
@@ -125,7 +126,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
       const queries = new Queries(new Pool());
       return queries.getByTimeRange(12345, 67890).catch(err => {
-        expect(err.message).toEqual('No result found');
+        expect(err).toBeInstanceOf(NotFoundError);
       });
     });
   });

--- a/plugins/with-postgres/src/__tests__/setup.test.ts
+++ b/plugins/with-postgres/src/__tests__/setup.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'pg';
+import setup from '../setup';
+
+jest.mock('pg');
+
+describe('withPostgres', () => {
+  let query, release, setupFn;
+  beforeEach(() => {
+    query = jest.fn();
+    release = jest.fn();
+    // @ts-ignore
+    Pool.mockImplementation(() => ({
+      connect: () => ({ query, release })
+    }));
+
+    setupFn = setup(new Pool());
+  });
+
+  test('creates the table if not exists', () => {
+    return setupFn().then(result => {
+      expect(result).toBe(true);
+      expect(query).toHaveBeenCalledWith(expect.stringMatching('CREATE TABLE IF NOT EXISTS builds'));
+    });
+  });
+
+  test('creates a multi-index', () => {
+    return setupFn().then(() => {
+      expect(query).toHaveBeenCalledWith('CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision)');
+    });
+  });
+
+  test('creates an index on timestamp', () => {
+    return setupFn().then(() => {
+      expect(query).toHaveBeenCalledWith('CREATE INDEX IF NOT EXISTS timestamp ON builds (timestamp)');
+    });
+  });
+
+  test('releases the client on complete', () => {
+    return setupFn().then(() => {
+      expect(release).toHaveBeenCalled();
+    });
+  });
+
+  test('releases the client on error', () => {
+    const error = new Error('tacos');
+    query.mockReturnValueOnce(Promise.reject(error));
+    return setupFn().catch(err => {
+      expect(release).toHaveBeenCalled();
+      expect(err).toBe(error);
+    });
+  });
+});

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -1,19 +1,12 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import { Pool } from 'pg';
 import Queries from './queries';
 import { ServerConfig } from '@build-tracker/server/src/server';
+import setup from './setup';
+import { Pool, PoolConfig } from 'pg';
 
-interface PostgresConfig {
-  user?: string;
-  host?: string;
-  database?: string;
-  password?: string;
-  port?: number;
-}
-
-export default function withPostgres(config: Partial<ServerConfig> & { pg: PostgresConfig }): ServerConfig {
+export default function withPostgres(config: Partial<ServerConfig> & { pg: PoolConfig }): ServerConfig {
   const { pg: pgConfig } = config;
 
   const pool = new Pool(pgConfig);
@@ -21,6 +14,7 @@ export default function withPostgres(config: Partial<ServerConfig> & { pg: Postg
 
   return {
     ...config,
+    setup: setup(pool),
     queries: {
       build: {
         byRevision: queries.getyByRevision,

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -17,7 +17,7 @@ export default function withPostgres(config: Partial<ServerConfig> & { pg: PoolC
     setup: setup(pool),
     queries: {
       build: {
-        byRevision: queries.getyByRevision,
+        byRevision: queries.getByRevision,
         insert: queries.insert
       },
       builds: {

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -9,7 +9,9 @@ import { Pool, PoolConfig } from 'pg';
 
 config();
 
-export default function withPostgres(config: Partial<ServerConfig> & { pg: PoolConfig }): ServerConfig {
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export default function withPostgres(config: Omit<ServerConfig, 'queries'> & { pg: PoolConfig }): ServerConfig {
   const { pg: pgConfig } = config;
 
   const pool = new Pool(pgConfig);

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -1,15 +1,19 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
+import { config } from 'dotenv';
 import Queries from './queries';
 import { ServerConfig } from '@build-tracker/server/src/server';
 import setup from './setup';
 import { Pool, PoolConfig } from 'pg';
 
+config();
+
 export default function withPostgres(config: Partial<ServerConfig> & { pg: PoolConfig }): ServerConfig {
   const { pg: pgConfig } = config;
 
   const pool = new Pool(pgConfig);
+
   const queries = new Queries(pool);
 
   return {

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -27,7 +27,8 @@ export default function withPostgres(config: Partial<ServerConfig> & { pg: PoolC
       builds: {
         byRevisions: queries.getByRevisions,
         byRevisionRange: queries.getByRevisionRange,
-        byTimeRange: queries.getByTimeRange
+        byTimeRange: queries.getByTimeRange,
+        recent: queries.getRecent
       }
     }
   };

--- a/plugins/with-postgres/src/index.ts
+++ b/plugins/with-postgres/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'pg';
+import Queries from './queries';
+import { ServerConfig } from '@build-tracker/server/src/server';
+
+interface PostgresConfig {
+  user?: string;
+  host?: string;
+  database?: string;
+  password?: string;
+  port?: number;
+}
+
+export default function withPostgres(config: Partial<ServerConfig> & { pg: PostgresConfig }): ServerConfig {
+  const { pg: pgConfig } = config;
+
+  const pool = new Pool(pgConfig);
+  const queries = new Queries(pool);
+
+  return {
+    ...config,
+    queries: {
+      build: {
+        byRevision: queries.getyByRevision,
+        insert: queries.insert
+      },
+      builds: {
+        byRevisions: queries.getByRevisions,
+        byRevisionRange: queries.getByRevisionRange,
+        byTimeRange: queries.getByTimeRange
+      }
+    }
+  };
+}

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -57,9 +57,18 @@ export default class Queries {
 
   public getByTimeRange = async (startTimestamp: number, endTimestamp: number): Promise<Array<BuildStruct>> => {
     const res = await this._pool.query(
-      'SELECT meta, artifacts FROM builds WHERE  timestamp >= $1 AND timestamp <= $2 ORDER BY timestamp',
+      'SELECT meta, artifacts FROM builds WHERE timestamp >= $1 AND timestamp <= $2 ORDER BY timestamp',
       [startTimestamp, endTimestamp]
     );
+    if (res.rowCount === 0) {
+      throw new NotFoundError();
+    }
+
+    return Promise.resolve(res.rows);
+  };
+
+  public getRecent = async (limit: number = 20): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds LIMIT $1 ORDER BY timestamp', [limit]);
     if (res.rowCount === 0) {
       throw new NotFoundError();
     }

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -12,7 +12,7 @@ export default class Queries {
     this._pool = pool;
   }
 
-  public getyByRevision = async (revision: string): Promise<BuildStruct> => {
+  public getByRevision = async (revision: string): Promise<BuildStruct> => {
     const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
     if (res.rowCount !== 1) {
       throw new Error('No result found');
@@ -27,7 +27,7 @@ export default class Queries {
       'INSERT INTO builds (revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, @4)',
       [
         build.getMetaValue('revision'),
-        build.timestamp,
+        build.meta.timestamp,
         build.getMetaValue('parentRevision'),
         build.meta,
         build.artifacts
@@ -35,7 +35,7 @@ export default class Queries {
     );
 
     if (res.rowCount !== 1) {
-      throw new Error('No result found');
+      throw new Error('Unable to insert build');
     }
 
     return Promise.resolve(build.getMetaValue('revision'));

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -4,6 +4,7 @@
 import Build from '@build-tracker/build';
 import { Build as BuildStruct } from '@build-tracker/server/src/types';
 import { Pool } from 'pg';
+import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
 
 export default class Queries {
   private _pool: Pool;
@@ -15,7 +16,7 @@ export default class Queries {
   public getByRevision = async (revision: string): Promise<BuildStruct> => {
     const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
     if (res.rowCount !== 1) {
-      throw new Error('No result found');
+      throw new NotFoundError();
     }
 
     return Promise.resolve(res.rows[0]);
@@ -44,14 +45,14 @@ export default class Queries {
   public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
     const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
     if (res.rowCount === 0) {
-      throw new Error('No result found');
+      throw new NotFoundError();
     }
 
     return Promise.resolve(res.rows);
   };
 
   public getByRevisionRange = async (startRevision: string, endRevision: string): Promise<Array<BuildStruct>> => {
-    throw new Error(`unimplemented ${startRevision} - ${endRevision}`);
+    throw new UnimplementedError(`revision range ${startRevision} - ${endRevision}`);
   };
 
   public getByTimeRange = async (startTimestamp: number, endTimestamp: number): Promise<Array<BuildStruct>> => {
@@ -60,7 +61,7 @@ export default class Queries {
       [startTimestamp, endTimestamp]
     );
     if (res.rowCount === 0) {
-      throw new Error('No result found');
+      throw new NotFoundError();
     }
 
     return Promise.resolve(res.rows);

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { Build as BuildStruct } from '@build-tracker/server/src/types';
+import { Pool } from 'pg';
+
+export default class Queries {
+  private _pool: Pool;
+
+  public constructor(pool: Pool) {
+    this._pool = pool;
+  }
+
+  public async getyByRevision(revision: string): Promise<BuildStruct> {
+    const client = await this._pool.connect();
+    const res = await client.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
+    if (res.rowCount !== 1) {
+      throw new Error('No result found');
+    }
+
+    return Promise.resolve(res.rows[0]);
+  }
+
+  public async insert({ meta, artifacts }: BuildStruct): Promise<string> {
+    const build = new Build(meta, artifacts);
+    const client = await this._pool.connect();
+    const res = await client.query(
+      'INSERT INTO builds (revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, @4)',
+      [
+        build.getMetaValue('revision'),
+        build.timestamp,
+        build.getMetaValue('parentRevision'),
+        build.meta,
+        build.artifacts
+      ]
+    );
+
+    if (res.rowCount !== 1) {
+      throw new Error('No result found');
+    }
+
+    return Promise.resolve(build.getMetaValue('revision'));
+  }
+
+  public async getByRevisions(...revisions: Array<string>): Promise<Array<BuildStruct>> {
+    const client = await this._pool.connect();
+    const res = await client.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
+    if (res.rowCount === 0) {
+      throw new Error('No result found');
+    }
+
+    return Promise.resolve(res.rows);
+  }
+
+  public async getByRevisionRange(startRevision: string, endRevision: string): Promise<Array<BuildStruct>> {
+    throw new Error(`unimplemented ${startRevision} - ${endRevision}`);
+  }
+
+  public async getByTimeRange(startTimestamp: number, endTimestamp: number): Promise<Array<BuildStruct>> {
+    const client = await this._pool.connect();
+    const res = await client.query(
+      'SELECT meta, artifacts FROM builds WHERE  timestamp >= $1 AND timestamp <= $2 ORDER BY timestamp',
+      [startTimestamp, endTimestamp]
+    );
+    if (res.rowCount === 0) {
+      throw new Error('No result found');
+    }
+
+    return Promise.resolve(res.rows);
+  }
+}

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -12,20 +12,18 @@ export default class Queries {
     this._pool = pool;
   }
 
-  public async getyByRevision(revision: string): Promise<BuildStruct> {
-    const client = await this._pool.connect();
-    const res = await client.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
+  public getyByRevision = async (revision: string): Promise<BuildStruct> => {
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
     if (res.rowCount !== 1) {
       throw new Error('No result found');
     }
 
     return Promise.resolve(res.rows[0]);
-  }
+  };
 
-  public async insert({ meta, artifacts }: BuildStruct): Promise<string> {
+  public insert = async ({ meta, artifacts }: BuildStruct): Promise<string> => {
     const build = new Build(meta, artifacts);
-    const client = await this._pool.connect();
-    const res = await client.query(
+    const res = await this._pool.query(
       'INSERT INTO builds (revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, @4)',
       [
         build.getMetaValue('revision'),
@@ -41,25 +39,23 @@ export default class Queries {
     }
 
     return Promise.resolve(build.getMetaValue('revision'));
-  }
+  };
 
-  public async getByRevisions(...revisions: Array<string>): Promise<Array<BuildStruct>> {
-    const client = await this._pool.connect();
-    const res = await client.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
+  public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
     if (res.rowCount === 0) {
       throw new Error('No result found');
     }
 
     return Promise.resolve(res.rows);
-  }
+  };
 
-  public async getByRevisionRange(startRevision: string, endRevision: string): Promise<Array<BuildStruct>> {
+  public getByRevisionRange = async (startRevision: string, endRevision: string): Promise<Array<BuildStruct>> => {
     throw new Error(`unimplemented ${startRevision} - ${endRevision}`);
-  }
+  };
 
-  public async getByTimeRange(startTimestamp: number, endTimestamp: number): Promise<Array<BuildStruct>> {
-    const client = await this._pool.connect();
-    const res = await client.query(
+  public getByTimeRange = async (startTimestamp: number, endTimestamp: number): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query(
       'SELECT meta, artifacts FROM builds WHERE  timestamp >= $1 AND timestamp <= $2 ORDER BY timestamp',
       [startTimestamp, endTimestamp]
     );
@@ -68,5 +64,5 @@ export default class Queries {
     }
 
     return Promise.resolve(res.rows);
-  }
+  };
 }

--- a/plugins/with-postgres/src/setup.ts
+++ b/plugins/with-postgres/src/setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'pg';
+
+export default function setup(pool: Pool): () => Promise<boolean> {
+  const setup = async (): Promise<boolean> => {
+    const client = await pool.connect();
+    try {
+      await client.query(`CREATE TABLE IF NOT EXISTS builds(
+  revision char(64) PRIMARY KEY NOT NULL,
+  parentRevision char(64),
+  timestamp int NOT NULL,
+  meta jsonb NOT NULL,
+  artifacts jsonb NOT NULL
+)`);
+      await client.query('CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision)');
+      await client.query('CREATE INDEX IF NOT EXISTS timestamp ON builds (timestamp)');
+    } catch (err) {
+      client.release();
+      throw err;
+    }
+    client.release();
+    return Promise.resolve(true);
+  };
+  return setup;
+}
+
+module.exports = setup;

--- a/plugins/with-postgres/tsconfig.json
+++ b/plugins/with-postgres/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -3,5 +3,6 @@ module.exports = {
   plugins: ['header'],
   rules: {
     'header/header': ['error', path.join(__dirname, '../config/copyright.txt')]
-  }
+  },
+  overrides: [{ files: '*.md', rules: { 'header/header': 'off' } }]
 };

--- a/src/api-errors/index.ts
+++ b/src/api-errors/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+export * from './src';

--- a/src/api-errors/jest.config.js
+++ b/src/api-errors/jest.config.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+module.exports = {
+  displayName: 'api-errors',
+  testEnvironment: 'node',
+  resetMocks: true,
+  rootDir: './',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  }
+};

--- a/src/api-errors/package.json
+++ b/src/api-errors/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@build-tracker/api-errors",
+  "version": "1.0.0",
+  "description": "Build Tracker API errors",
+  "author": "Paul Armstrong <paul@spaceyak.com>",
+  "repository": "git@github.com:paularmstrong/build-tracker.git",
+  "license": "MIT",
+  "main": "dist",
+  "types": "index.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/src/api-errors/src/index.ts
+++ b/src/api-errors/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+export class NotFoundError extends Error {
+  public readonly status = 404;
+
+  public constructor(message?: string) {
+    super(`No builds found${message ? `: ${message}` : ''}`);
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}
+
+export class UnimplementedError extends Error {
+  public readonly status = 501;
+
+  public constructor(message?: string) {
+    super(`Method not implemented${message ? `: ${message}` : ''}`);
+    Object.setPrototypeOf(this, UnimplementedError.prototype);
+  }
+}

--- a/src/api-errors/tsconfig.json
+++ b/src/api-errors/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,0 +1,3 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@types/d3-scale-chromatic": "^1.3.1",
+    "cross-fetch": "^3.0.1",
     "d3-axis": "^1.0.12",
     "d3-color": "^1.2.3",
     "d3-scale": "^2.2.2",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -4,7 +4,7 @@
   "description": "Build Tracker client side application for tracking builds over time",
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "repository": "git@github.com:paularmstrong/build-tracker.git",
-  "main": "dist/stats.json",
+  "main": ".",
   "license": "MIT",
   "scripts": {
     "prebuild": "mkdirp dist",

--- a/src/app/src/client/index.tsx
+++ b/src/app/src/client/index.tsx
@@ -7,5 +7,5 @@ import ReactDOM from 'react-dom';
 
 AppRegistry.registerComponent('App', () => Main);
 // @ts-ignore
-const { element } = AppRegistry.getApplication('App', { initialProps: {} });
+const { element } = AppRegistry.getApplication('App', { initialProps: window.__PROPS__ || {} });
 ReactDOM.hydrate(element, document.getElementById('root'));

--- a/src/cli/src/modules/config.ts
+++ b/src/cli/src/modules/config.ts
@@ -4,6 +4,7 @@
 import cosmiconfig from 'cosmiconfig';
 
 interface Config {
+  applicationUrl: string;
   artifacts: Array<string>;
   baseDir: string;
   cwd: string;

--- a/src/comparator/src/index.ts
+++ b/src/comparator/src/index.ts
@@ -143,6 +143,10 @@ export default class BuildComparator {
   }
 
   public get artifactNames(): Array<string> {
+    if (this.builds.length === 0) {
+      return [];
+    }
+
     if (!this._artifactNames) {
       this._artifactNames = Array.prototype.concat
         .apply([], this.builds.map(build => build.artifacts))
@@ -160,6 +164,10 @@ export default class BuildComparator {
   }
 
   public get sizeKeys(): Array<string> {
+    if (this.builds.length === 0) {
+      return [];
+    }
+
     if (!this._sizeKeys) {
       this._sizeKeys = Object.keys(this.builds[0].artifacts[0].sizes).sort();
       const allSizeKeys = new Set();
@@ -179,6 +187,10 @@ export default class BuildComparator {
   }
 
   public get buildDeltas(): Array<Array<BuildDelta>> {
+    if (this.builds.length === 0) {
+      return [];
+    }
+
     if (!this._buildDeltas) {
       this._buildDeltas = this.builds.map((baseBuild, i) => {
         return this.builds.slice(0, i).map(prevBuild => {

--- a/src/fixtures/cli-configs/commonjs/build-tracker.config.js
+++ b/src/fixtures/cli-configs/commonjs/build-tracker.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  applicationUrl: '',
   artifacts: ['../fakedist/*.js'],
   baseDir: path.resolve(__dirname, 'fakedist'),
   cwd: __dirname,

--- a/src/fixtures/cli-configs/rc/.build-trackerrc.js
+++ b/src/fixtures/cli-configs/rc/.build-trackerrc.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  applicationUrl: '',
   artifacts: ['../fakedist/*.js'],
   baseDir: path.resolve(__dirname, 'fakedist'),
   cwd: __dirname

--- a/src/fixtures/server-configs/build-tracker.config.js
+++ b/src/fixtures/server-configs/build-tracker.config.js
@@ -5,5 +5,6 @@ const fakeBuild = require('../builds/01141f29743fb2bdd7e176cf919fc964025cea5a.js
 
 module.exports = {
   getParentBuild: () => Promise.resolve(fakeBuild),
-  port: 3000
+  port: 3000,
+  setup: () => Promise.resolve()
 };

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -14,6 +14,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
+    "@build-tracker/api-errors": "1.0.0",
     "@build-tracker/app": "1.0.0",
     "@build-tracker/build": "1.0.0",
     "@build-tracker/comparator": "1.0.0",

--- a/src/server/src/api/index.ts
+++ b/src/server/src/api/index.ts
@@ -5,7 +5,7 @@ import { AppConfig } from '@build-tracker/types';
 import express from 'express';
 import { insertBuild } from './insert';
 import { Handlers, Queries } from '../types';
-import { queryByRevision, queryByRevisionRange, queryByRevisions, queryByTimeRange } from './read';
+import { queryByRecent, queryByRevision, queryByRevisionRange, queryByRevisions, queryByTimeRange } from './read';
 
 const defaultBuildInsert = (): Promise<void> => Promise.resolve();
 
@@ -17,6 +17,7 @@ const middleware = (
 ): express.Router => {
   const { onBuildInsert = defaultBuildInsert } = handlers || {};
   router.post('/api/builds', insertBuild(queries.build.byRevision, appConfig, onBuildInsert));
+  router.get('/api/builds/:limit?', queryByRecent(queries.builds));
   router.get('/api/builds/range/:startRevision..:endRevision', queryByRevisionRange(queries.builds));
   router.get('/api/builds/time/:startTimestamp..:endTimestamp', queryByTimeRange(queries.builds));
   router.get('/api/builds/list/*', queryByRevisions(queries.builds));

--- a/src/server/src/api/read.ts
+++ b/src/server/src/api/read.ts
@@ -11,9 +11,9 @@ export const queryByRevision = (queries: Queries['build']): RequestHandler => (r
     .then(build => {
       res.send(build);
     })
-    .catch(() => {
-      res.status(500);
-      res.end();
+    .catch(error => {
+      res.status(error.status || 500);
+      res.send({ error: error.message });
     });
 };
 
@@ -27,9 +27,9 @@ export const queryByRevisionRange = (queries: Queries['builds']): RequestHandler
     .then(builds => {
       res.send(builds);
     })
-    .catch(() => {
-      res.status(500);
-      res.end();
+    .catch(error => {
+      res.status(error.status || 500);
+      res.send({ error: error.message });
     });
 };
 
@@ -40,9 +40,9 @@ export const queryByTimeRange = (queries: Queries['builds']): RequestHandler => 
     .then(builds => {
       res.send(builds);
     })
-    .catch(() => {
-      res.status(500);
-      res.end();
+    .catch(error => {
+      res.status(error.status || 500);
+      res.send({ error: error.message });
     });
 };
 
@@ -53,8 +53,8 @@ export const queryByRevisions = (queries: Queries['builds']): RequestHandler => 
     .then(builds => {
       res.send(builds);
     })
-    .catch(() => {
-      res.status(500);
-      res.end();
+    .catch(error => {
+      res.status(error.status || 500);
+      res.send({ error: error.message });
     });
 };

--- a/src/server/src/api/read.ts
+++ b/src/server/src/api/read.ts
@@ -58,3 +58,16 @@ export const queryByRevisions = (queries: Queries['builds']): RequestHandler => 
       res.send({ error: error.message });
     });
 };
+
+export const queryByRecent = (queries: Queries['builds']): RequestHandler => (req: Request, res: Response): void => {
+  const { limit } = req.params;
+  queries
+    .recent(limit)
+    .then(builds => {
+      res.send(builds);
+    })
+    .catch(error => {
+      res.status(error.status || 500);
+      res.send({ error: error.message });
+    });
+};

--- a/src/server/src/commands/.eslintrc.js
+++ b/src/server/src/commands/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-console': 'off'
+  }
+};

--- a/src/server/src/commands/__tests__/setup.test.ts
+++ b/src/server/src/commands/__tests__/setup.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Command from '../setup';
+import * as path from 'path';
+import yargs from 'yargs';
+
+describe('run command', () => {
+  describe('builder', () => {
+    test('looks for the config in the process working directory', () => {
+      jest
+        .spyOn(process, 'cwd')
+        .mockReturnValue(path.join(path.dirname(require.resolve('@build-tracker/fixtures')), 'server-configs'));
+
+      const args = Command.builder(yargs([]));
+      expect(args.argv.config).toEqual(
+        require.resolve('@build-tracker/fixtures/server-configs/build-tracker.config.js')
+      );
+    });
+
+    test('resolves the config path for requires', () => {
+      jest.spyOn(process, 'cwd').mockReturnValue(path.join(__dirname, '../../..'));
+
+      const args = Command.builder(yargs(['--config', './fixtures/server-configs/build-tracker.config.js']));
+      expect(args.argv.config).toEqual(
+        path.join(__dirname, '../../../fixtures/server-configs/build-tracker.config.js')
+      );
+    });
+  });
+
+  describe('handler', () => {
+    test('runs the setup command for the config', () => {
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      const configPath = require.resolve('@build-tracker/fixtures/server-configs/build-tracker.config.js');
+      const config = require(configPath);
+      const setupSpy = jest.spyOn(config, 'setup');
+      Command.handler({ config: configPath });
+      expect(setupSpy).toHaveBeenCalled();
+    });
+
+    test('exits if no setup found', () => {
+      const configPath = require.resolve('@build-tracker/fixtures/server-configs/build-tracker.config.js');
+      const config = require(configPath);
+      delete config.setup;
+      expect(Command.handler({ config: configPath })).rejects.toThrow();
+    });
+  });
+});

--- a/src/server/src/commands/setup.ts
+++ b/src/server/src/commands/setup.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as path from 'path';
+import { Argv } from 'yargs';
+import { ServerConfig } from '../server';
+
+export const command = 'setup';
+
+export const description = 'Run the Build Tracker setup';
+
+interface Args {
+  config: string;
+}
+
+const group = 'Setup';
+
+export const builder = (yargs): Argv<Args> =>
+  yargs.usage(`Usage: $0 ${command}`).option('config', {
+    alias: 'c',
+    coerce: v => path.join(process.cwd(), v),
+    default: 'build-tracker.config.js',
+    description: 'path to the build-tracker config file',
+    group,
+    normalize: true
+  });
+
+export const handler = async (args: Args): Promise<void> => {
+  const config = require(args.config) as ServerConfig;
+  await config.setup();
+  console.log('Successfully set up your database');
+};

--- a/src/server/src/server.ts
+++ b/src/server/src/server.ts
@@ -19,6 +19,7 @@ export interface ServerConfig extends AppConfig {
   port?: number;
   setup?: () => Promise<boolean>;
   queries: Queries;
+  url: string;
 }
 
 const app = express();
@@ -26,7 +27,7 @@ const logger = pino();
 const reqLogger = expressPino({ logger });
 
 export default function runBuildTracker(config: ServerConfig): void {
-  const { handlers, port = 3000, queries } = config;
+  const { handlers, port = 3000, queries, url } = config;
   const IN_DEV = process.env.NODE_ENV !== 'production' && config.dev;
   app.use(reqLogger);
   app.use(bodyParser.json());
@@ -35,6 +36,7 @@ export default function runBuildTracker(config: ServerConfig): void {
 
   app.use((_req: Request, res: Response, next: NextFunction) => {
     res.locals.nonce = crypto.randomBytes(16).toString('base64');
+    res.locals.url = url;
     next();
   });
 

--- a/src/server/src/server.ts
+++ b/src/server/src/server.ts
@@ -47,14 +47,14 @@ export default function runBuildTracker(config: ServerConfig): void {
   if (IN_DEV) {
     const middleware = require('webpack-dev-middleware');
     const webpack = require('webpack');
-    const compiler = webpack(require(path.join(APP_ROOT, '../config/webpack.config'))({ port }));
+    const compiler = webpack(require(path.join(APP_ROOT, 'config/webpack.config'))({ port }));
     app.use(middleware(compiler, { noInfo: true, publicPath: '/', serverSideRender: true }));
     app.use(require('webpack-hot-middleware')(compiler.compilers.find(compiler => compiler.name === 'client')));
     app.use(require('webpack-hot-server-middleware')(compiler));
   } else {
-    const serverRenderer = require(path.join(APP_ROOT, 'server/main')).default;
-    const stats = require(path.join(APP_ROOT, 'stats.json'));
-    app.use(express.static(APP_ROOT));
+    const serverRenderer = require(path.join(APP_ROOT, 'dist/server/main')).default;
+    const stats = require(path.join(APP_ROOT, 'dist/stats.json'));
+    app.use(express.static(path.join(APP_ROOT, 'dist')));
     app.use(serverRenderer(stats));
   }
 

--- a/src/server/src/server.ts
+++ b/src/server/src/server.ts
@@ -17,6 +17,7 @@ export interface ServerConfig extends AppConfig {
   dev?: boolean;
   handlers?: Handlers;
   port?: number;
+  setup?: () => Promise<boolean>;
   queries: Queries;
 }
 

--- a/src/server/src/types.ts
+++ b/src/server/src/types.ts
@@ -4,7 +4,7 @@
 import Comparator from '@build-tracker/comparator';
 import { Artifact, BuildMeta } from '@build-tracker/build';
 
-interface Build {
+export interface Build {
   meta: BuildMeta;
   artifacts: Array<Artifact<{}>>;
 }
@@ -12,11 +12,12 @@ interface Build {
 export interface Queries {
   build: {
     byRevision: (revision: string) => Promise<Build>;
+    insert: (build: Build) => Promise<string>;
   };
   builds: {
     byRevisions: (...revisions: Array<string>) => Promise<Array<Build>>;
     byRevisionRange: (startRevision: string, endRevision: string) => Promise<Array<Build>>;
-    byTimeRange: (startTimestamp: number, endTimestamp: string) => Promise<Array<Build>>;
+    byTimeRange: (startTimestamp: number, endTimestamp: number) => Promise<Array<Build>>;
   };
 }
 

--- a/src/server/src/types.ts
+++ b/src/server/src/types.ts
@@ -18,6 +18,7 @@ export interface Queries {
     byRevisions: (...revisions: Array<string>) => Promise<Array<Build>>;
     byRevisionRange: (startRevision: string, endRevision: string) => Promise<Array<Build>>;
     byTimeRange: (startTimestamp: number, endTimestamp: number) => Promise<Array<Build>>;
+    recent: (limit: number) => Promise<Array<Build>>;
   };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "sourceMap": true,
     "target": "es5"
   },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**", "plugins/**/dist/**"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,14 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-fetch@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.1.tgz#3f207bbd829a76e9aa2a953348bd1f2a3cf388a7"
+  integrity sha512-qWtpgBAF8ioqBOddRD+pHhrdzm/UWOArkrlIU7c08DlNbOxo5GfUbSY2vr90ZypWf0raW+HNN1F38pi5CEOjiQ==
+  dependencies:
+    node-fetch "2.3.0"
+    whatwg-fetch "3.0.0"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -6511,6 +6519,11 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@2.3.0, node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -6518,11 +6531,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -9875,7 +9883,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,13 @@
   dependencies:
     "@types/d3-selection" "*"
 
+"@types/dotenv@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-6.1.0.tgz#fba2bfd1f28a46eadaa049f3313ebb89bdedfc53"
+  integrity sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3118,6 +3125,11 @@ dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
+
+dotenv@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
+  integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
 
 duplexer@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,21 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.10.4.tgz#3f5fc4f0f322805f009e00ab35a2ff3d6b778e42"
   integrity sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==
 
+"@types/pg-types@*":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@types/pg-types/-/pg-types-1.11.4.tgz#8d7c59fb509ce3dca3f8bae589252051c639a9a8"
+  integrity sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==
+  dependencies:
+    moment ">=2.14.0"
+
+"@types/pg@^7.4.13":
+  version "7.4.13"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.4.13.tgz#4630494096bceee5ee562339502e3448c09703a8"
+  integrity sha512-jk/hFADnywyjnWXZ6IeNsAk2lZtKDInZWGs1ASxmLb3QBpwLDGcSvH5s6IIRlPqsXjwzu8btnNbQ5Cx+AX/CjA==
+  dependencies:
+    "@types/node" "*"
+    "@types/pg-types" "*"
+
 "@types/prop-types@*":
   version "15.5.9"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.9.tgz#f2d14df87b0739041bc53a7d75e3d77d726a3ec0"
@@ -1880,6 +1895,11 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
+
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -6337,6 +6357,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@>=2.14.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7010,6 +7035,11 @@ p-waterfall@^1.0.0:
   dependencies:
     p-reduce "^1.0.0"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pacote@^9.4.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.4.1.tgz#f0af2a52d241bce523d39280ac810c671db62279"
@@ -7225,6 +7255,52 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+pg-connection-string@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
+  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-2.0.6.tgz#7b561a482feb0a0e599b58b5137fd2db3ad8111c"
+  integrity sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g==
+
+pg-types@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.0.0.tgz#038ddc302a0340efcdb46d0581cc7caa2303cbba"
+  integrity sha512-THUD7gQll5tys+5eQ8Rvs7DjHiIC3bLqixk3gMN9Hu8UrCBAOjf35FoI39rTGGc3lM2HU/R+Knpxvd11mCwOMA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.0"
+    postgres-interval "^1.1.0"
+
+pg@^7.8.2:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.8.2.tgz#d53ffcbbaa789e15e80ffec570603294d90116e8"
+  integrity sha512-5U4fjV43DnQxelkhyPdU3YfUbYVa21bNmreXRCM/gFFw09YxWaitWWITm/u0twUNF5EYOSDhkgyEAocgtpP9JQ==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "0.1.3"
+    pg-pool "^2.0.4"
+    pg-types "~2.0.0"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  integrity sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
+  dependencies:
+    split "^1.0.0"
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -7323,6 +7399,28 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.3.tgz#e2d89702efdb258ff9d9cee0fe91bd06975257a8"
+  integrity sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prebuild-install@^5.2.1:
   version "5.2.4"
@@ -8194,6 +8292,11 @@ semver-compare@^1.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
+  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
 
 semver@5.5.0:
   version "5.5.0"


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Fixes #33 
Needing to manually set up common database configurations is cumbersome. We should have plugins for common setups that can be used mostly out of the box.

# Solution
This implements `@build-tracker/plugin-with-postgres`.

To use, create a `build-tracker.config.js` file and wrap your configuration:

```js
const withPostgres = require('@build-tracker/plugin-with-postgres');

module.exports = withPostgres({
  pg: {
    user: '',     // default: process.env.PGUSER
    host: '',     // default: process.env.PGHOST
    database: '', // default: process.env.PGPASSWORD
    password: '', // default: process.env.PGDATABASE
    port: 5432,   // default: process.env.PGPORT
    ssl: true
  }
});
```

### Changes

* Adds a new command to the server cli: `bt-server setup -c build-tracker.config.js`
* DB plugins should add a `setup` command to the configuration that creates or updates the database as needed

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
