### PR TITLE
Add @build-tracker/plugin-with-mariadb

### DIFF
--- a/config/mariadb.js
+++ b/config/mariadb.js
@@ -2,7 +2,7 @@ const withMaria = require('@build-tracker/plugin-with-mariadb').default;
 const { BudgetLevel, BudgetType } = require('@build-tracker/types');
 
 module.exports = withMaria({
-  defaultBranch: 'next',
+  defaultBranch: 'master',
   dev: true,
   artifacts: {
     groups: [

--- a/config/mariadb.js
+++ b/config/mariadb.js
@@ -1,0 +1,24 @@
+const withMaria = require('@build-tracker/plugin-with-mariadb').default;
+const { BudgetLevel, BudgetType } = require('@build-tracker/types');
+
+module.exports = withMaria({
+  defaultBranch: 'next',
+  dev: true,
+  artifacts: {
+    groups: [
+      {
+        name: 'Web App',
+        artifactMatch: /^app\/client/,
+        budgets: [{ level: BudgetLevel.ERROR, sizeKey: 'gzip', type: BudgetType.SIZE, maximum: 150000 }]
+      }
+    ]
+  },
+  mariadb: {
+    user: 'root',
+    password: 'tacos',
+    database: 'buildtracker',
+    host: '127.0.0.1',
+    port: 3306
+  },
+  url: 'http://localhost:3000'
+});

--- a/docs/docs/plugins/index.md
+++ b/docs/docs/plugins/index.md
@@ -5,4 +5,5 @@ title: Plugins
 
 Plugins are community-developed config composers that make running your server simple. Most plugins remove the need to develop custom database integrations.
 
-- [withPostgres](/docs/withPostgres)
+- [withPostgres](/docs/plugins/withPostgres)
+- [withMariadb](/docs/plugins/withMariadb)

--- a/docs/docs/plugins/with-mariadb.md
+++ b/docs/docs/plugins/with-mariadb.md
@@ -1,6 +1,7 @@
-# @build-tracker/plugin-with-postgres
-
-A server-configuration plugin for Build Tracker to enable reading build data from a MariaDB database.
+---
+id: withMariadb
+title: MariaDB
+---
 
 Connecting your Build Tracker application to a Maria database is easy with the help of `@build-tracker/plugin-with-mariadb`
 

--- a/docs/docs/plugins/with-mariadb.md
+++ b/docs/docs/plugins/with-mariadb.md
@@ -25,7 +25,7 @@ module.exports = withMariadb({
     user: '', // default: process.env.MARIAUSER
     host: '', // default: process.env.MARIAHOST
     database: '', // default: process.env.MARIADATABASE
-    password: '', // default: process.envMARIAPASSWORD.
+    password: '', // default: process.env.MARIAPASSWORD
     port: 3306 // default: process.env.MARIAPORT
   }
 });

--- a/docs/docs/plugins/with-postgres.md
+++ b/docs/docs/plugins/with-postgres.md
@@ -25,8 +25,8 @@ module.exports = withPostgres({
     connectionString: '', // default: process.env.DATABASE_URL
     user: '', // default: process.env.PGUSER
     host: '', // default: process.env.PGHOST
-    database: '', // default: process.env.PGPASSWORD
-    password: '', // default: process.env.PGDATABASE
+    database: '', // default: process.env.PGDATABASE
+    password: '', // default: process.env.PGPASSWORD
     port: 5432, // default: process.env.PGPORT
     ssl: true
   }

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Getting Started": ["installation", "budgets"],
     "Configuration": ["configuration-app", "configuration-cli"],
-    "Plugins": ["plugins", "withPostgres"],
+    "Plugins": ["plugins/plugins", "plugins/withPostgres", "plugins/withMariadb"],
     "Contributing": ["contributing"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   ],
   "scripts": {
     "dev": "ts-node src/server/src/index.ts run -c ./config/fixtures.js",
+    "dev:maria": "ts-node src/server/src/index.ts run -c ./config/mariadb.js",
+    "dev:postgres": "ts-node src/server/src/index.ts run -c ./config/postgres.js",
     "docs": "cd docs/website && yarn start",
     "prebuild": "yarnpkg clean",
     "build": "lerna run build --stream --parallel",

--- a/plugins/with-mariadb/README.md
+++ b/plugins/with-mariadb/README.md
@@ -1,0 +1,53 @@
+# @build-tracker/plugin-with-postgres
+
+A server-configuration plugin for Build Tracker to enable reading build data from a Postgres database.
+
+Wrap your server's `build-tracker.config.js` configuration with `withPostgres` and include the `pg` options object:
+
+```js
+const withPostgres = require('@build-tracker/plugin-with-postgres');
+
+module.exports = withPostgres({
+  pg: {
+    connectionString: '', // default: process.env.DATABASE_URL
+    user: '', // default: process.env.PGUSER
+    host: '', // default: process.env.PGHOST
+    database: '', // default: process.env.PGPASSWORD
+    password: '', // default: process.env.PGDATABASE
+    port: 5432, // default: process.env.PGPORT
+    ssl: true
+  }
+});
+```
+
+## Configuration
+
+All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
+
+### `connectionString: string = process.env.DATABASE_URL`
+
+Optional. Use a single connection string to bypass the individual configs for `host`, `database`, `user`, `password`, and `port`.
+
+### `host: string = process.env.PGHOST`
+
+Database host.
+
+### `database: string = process.env.PGPASSWORD`
+
+Database name.
+
+### `user: string = process.env.PGUSER`
+
+Database username with read access.
+
+### `password: string = process.env.PGDATABASE`
+
+Password for the given database username.
+
+### `port: number = process.env.PGPORT = 5432`
+
+Database host port.
+
+### `ssl: boolean = false`
+
+Set to true to connect to your host using SSL (if supported).

--- a/plugins/with-mariadb/README.md
+++ b/plugins/with-mariadb/README.md
@@ -24,7 +24,7 @@ module.exports = withMariadb({
     user: '', // default: process.env.MARIAUSER
     host: '', // default: process.env.MARIAHOST
     database: '', // default: process.env.MARIADATABASE
-    password: '', // default: process.envMARIAPASSWORD.
+    password: '', // default: process.env.MARIAPASSWORD
     port: 3306 // default: process.env.MARIAPORT
   }
 });

--- a/plugins/with-mariadb/jest.config.js
+++ b/plugins/with-mariadb/jest.config.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+module.exports = {
+  displayName: 'with-mariadb',
+  testEnvironment: 'node',
+  resetMocks: true,
+  rootDir: './',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  }
+};

--- a/plugins/with-mariadb/package.json
+++ b/plugins/with-mariadb/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@build-tracker/plugin-with-mariadb",
+  "version": "1.0.0",
+  "description": "Build Tracker server plugin for MariaDB",
+  "author": "Paul Armstrong <paul@spaceyak.com>",
+  "repository": "git@github.com:paularmstrong/build-tracker.git",
+  "license": "MIT",
+  "main": "dist",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@build-tracker/api-errors": "1.0.0",
+    "dotenv": "^7.0.0",
+    "mariadb": "^2.0.5"
+  },
+  "devDependencies": {
+    "@build-tracker/types": "1.0.0",
+    "@types/dotenv": "^6.1.0"
+  }
+}

--- a/plugins/with-mariadb/src/__tests__/index.test.ts
+++ b/plugins/with-mariadb/src/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Mariadb from 'mariadb';
+import withMariadb from '../';
+
+const url = 'https://build-tracker.local';
+
+describe('withMariadb', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    jest.spyOn(Mariadb, 'createPool').mockImplementation(() => ({}));
+  });
+
+  test('preserves user-set config', () => {
+    expect(withMariadb({ mariadb: {}, port: 1234, url })).toMatchObject({ port: 1234 });
+  });
+
+  test('adds setup', () => {
+    expect(withMariadb({ mariadb: {}, url })).toHaveProperty('setup');
+  });
+
+  test('adds queries', () => {
+    expect(withMariadb({ mariadb: {}, url })).toMatchObject({
+      queries: {
+        build: {
+          byRevision: expect.any(Function),
+          insert: expect.any(Function)
+        },
+        builds: {
+          byRevisions: expect.any(Function),
+          byRevisionRange: expect.any(Function),
+          byTimeRange: expect.any(Function)
+        }
+      }
+    });
+  });
+});

--- a/plugins/with-mariadb/src/__tests__/queries.test.ts
+++ b/plugins/with-mariadb/src/__tests__/queries.test.ts
@@ -19,7 +19,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [row] }));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevision('12345').then(res => {
-        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision = $1', ['12345']);
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision = ?', ['12345']);
         expect(res).toEqual(row);
       });
     });
@@ -49,7 +49,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [build] }));
       return queries.insert(build).then(res => {
         expect(query).toHaveBeenCalledWith(
-          'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, $4, $5, $6)',
+          'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES (?, ?, ?, ?, ?, ?)',
           ['master', '12345', now, 'abcdef', JSON.stringify(build.meta), JSON.stringify(build.artifacts)]
         );
         expect(res).toEqual('12345');
@@ -77,7 +77,7 @@ describe('withPostgres', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevisions('12345', 'abcde').then(res => {
-        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in $1', [
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in ?', [
           ['12345', 'abcde']
         ]);
         expect(res).toEqual([row1, row2]);
@@ -110,7 +110,7 @@ describe('withPostgres', () => {
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByTimeRange(12345, 67890, 'tacos').then(res => {
         expect(query).toHaveBeenCalledWith(
-          'SELECT meta, artifacts FROM builds WHERE timestamp >= $1 AND timestamp <= $2 AND branch = $3 ORDER BY timestamp',
+          'SELECT meta, artifacts FROM builds WHERE timestamp >= ? AND timestamp <= ? AND branch = ? ORDER BY timestamp',
           [12345, 67890, 'tacos']
         );
         expect(res).toEqual([row1, row2]);
@@ -134,7 +134,7 @@ describe('withPostgres', () => {
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getRecent(2, 'master').then(res => {
         expect(query).toHaveBeenCalledWith(
-          'SELECT meta, artifacts FROM builds WHERE branch = $1 ORDER BY timestamp LIMIT $2',
+          'SELECT meta, artifacts FROM builds WHERE branch = ? ORDER BY timestamp LIMIT ?',
           ['master', 2]
         );
         expect(res).toEqual([row1, row2]);

--- a/plugins/with-mariadb/src/__tests__/queries.test.ts
+++ b/plugins/with-mariadb/src/__tests__/queries.test.ts
@@ -5,7 +5,24 @@ import * as Mariadb from 'mariadb';
 import Queries from '../queries';
 import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
 
-describe('withPostgres', () => {
+const row1Result = {
+  meta: { branch: 'master', revision: '12345' },
+  artifacts: []
+};
+const row2Result = {
+  meta: { branch: 'master', revision: 'abcde' },
+  artifacts: []
+};
+const row1 = {
+  meta: Buffer.from(JSON.stringify(row1Result.meta)),
+  artifacts: Buffer.from(JSON.stringify(row1Result.artifacts))
+};
+const row2 = {
+  meta: Buffer.from(JSON.stringify(row2Result.meta)),
+  artifacts: Buffer.from(JSON.stringify(row2Result.artifacts))
+};
+
+describe('withMariadb queries', () => {
   let query;
   beforeEach(() => {
     query = jest.fn();
@@ -15,17 +32,16 @@ describe('withPostgres', () => {
 
   describe('getByRevision', () => {
     test('selects meta and artifacts', () => {
-      const row = { meta: {}, artifacts: [] };
-      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [row] }));
+      query.mockReturnValue(Promise.resolve([row1]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevision('12345').then(res => {
         expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision = ?', ['12345']);
-        expect(res).toEqual(row);
+        expect(res).toEqual(row1Result);
       });
     });
 
     test('throws with no results', () => {
-      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      query.mockReturnValue(Promise.resolve([]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevision('12345').catch(err => {
         expect(err).toBeInstanceOf(NotFoundError);
@@ -46,11 +62,11 @@ describe('withPostgres', () => {
         },
         artifacts: []
       };
-      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [build] }));
+      query.mockReturnValue(Promise.resolve(row1));
       return queries.insert(build).then(res => {
         expect(query).toHaveBeenCalledWith(
           'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES (?, ?, ?, ?, ?, ?)',
-          ['master', '12345', now, 'abcdef', JSON.stringify(build.meta), JSON.stringify(build.artifacts)]
+          ['master', '12345', now, 'abcdef', build.meta, build.artifacts]
         );
         expect(res).toEqual('12345');
       });
@@ -63,7 +79,7 @@ describe('withPostgres', () => {
         meta: { branch: 'master', revision: 'abcdef', timestamp: now, parentRevision: '12345' },
         artifacts: []
       };
-      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      query.mockReturnValue(Promise.resolve([]));
       return queries.insert(build).catch(err => {
         expect(err.message).toEqual('Unable to insert build');
       });
@@ -72,20 +88,18 @@ describe('withPostgres', () => {
 
   describe('getByRevisions', () => {
     test('selects meta and artifacts', () => {
-      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
-      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
-      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      query.mockReturnValue(Promise.resolve([row1, row2]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevisions('12345', 'abcde').then(res => {
         expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in ?', [
           ['12345', 'abcde']
         ]);
-        expect(res).toEqual([row1, row2]);
+        expect(res).toEqual([row1Result, row2Result]);
       });
     });
 
     test('throws with no results', () => {
-      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      query.mockReturnValue(Promise.resolve([]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByRevisions('12345', 'abcde').catch(err => {
         expect(err).toBeInstanceOf(NotFoundError);
@@ -104,21 +118,19 @@ describe('withPostgres', () => {
 
   describe('getByTimeRange', () => {
     test('selects meta and artifacts', () => {
-      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
-      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
-      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      query.mockReturnValue(Promise.resolve([row1, row2]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByTimeRange(12345, 67890, 'tacos').then(res => {
         expect(query).toHaveBeenCalledWith(
           'SELECT meta, artifacts FROM builds WHERE timestamp >= ? AND timestamp <= ? AND branch = ? ORDER BY timestamp',
           [12345, 67890, 'tacos']
         );
-        expect(res).toEqual([row1, row2]);
+        expect(res).toEqual([row1Result, row2Result]);
       });
     });
 
     test('throws with no results', () => {
-      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      query.mockReturnValue(Promise.resolve([]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getByTimeRange(12345, 67890, 'tacos').catch(err => {
         expect(err).toBeInstanceOf(NotFoundError);
@@ -128,21 +140,19 @@ describe('withPostgres', () => {
 
   describe('getRecent', () => {
     test('returns N most recent', () => {
-      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
-      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
-      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      query.mockReturnValue(Promise.resolve([row1, row2]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getRecent(2, 'master').then(res => {
         expect(query).toHaveBeenCalledWith(
           'SELECT meta, artifacts FROM builds WHERE branch = ? ORDER BY timestamp LIMIT ?',
           ['master', 2]
         );
-        expect(res).toEqual([row1, row2]);
+        expect(res).toEqual([row1Result, row2Result]);
       });
     });
 
     test('throws with no results', () => {
-      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      query.mockReturnValue(Promise.resolve([]));
       const queries = new Queries(Mariadb.createPool({}));
       return queries.getRecent(undefined, 'tacos').catch(err => {
         expect(err).toBeInstanceOf(NotFoundError);

--- a/plugins/with-mariadb/src/__tests__/queries.test.ts
+++ b/plugins/with-mariadb/src/__tests__/queries.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Mariadb from 'mariadb';
+import Queries from '../queries';
+import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
+
+describe('withPostgres', () => {
+  let query;
+  beforeEach(() => {
+    query = jest.fn();
+    // @ts-ignore
+    jest.spyOn(Mariadb, 'createPool').mockImplementation(() => ({ query }));
+  });
+
+  describe('getByRevision', () => {
+    test('selects meta and artifacts', () => {
+      const row = { meta: {}, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [row] }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByRevision('12345').then(res => {
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision = $1', ['12345']);
+        expect(res).toEqual(row);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByRevision('12345').catch(err => {
+        expect(err).toBeInstanceOf(NotFoundError);
+      });
+    });
+  });
+
+  describe('insert', () => {
+    test('returns the revision on insert', () => {
+      const queries = new Queries(Mariadb.createPool({}));
+      const now = Date.now();
+      const build = {
+        meta: {
+          branch: 'master',
+          revision: { value: '12345', url: 'https://build-tracker.local' },
+          timestamp: now,
+          parentRevision: 'abcdef'
+        },
+        artifacts: []
+      };
+      query.mockReturnValue(Promise.resolve({ rowCount: 1, rows: [build] }));
+      return queries.insert(build).then(res => {
+        expect(query).toHaveBeenCalledWith(
+          'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, $4, $5, $6)',
+          ['master', '12345', now, 'abcdef', JSON.stringify(build.meta), JSON.stringify(build.artifacts)]
+        );
+        expect(res).toEqual('12345');
+      });
+    });
+
+    test('rejects if rowCount is not 1', () => {
+      const queries = new Queries(Mariadb.createPool({}));
+      const now = Date.now();
+      const build = {
+        meta: { branch: 'master', revision: 'abcdef', timestamp: now, parentRevision: '12345' },
+        artifacts: []
+      };
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      return queries.insert(build).catch(err => {
+        expect(err.message).toEqual('Unable to insert build');
+      });
+    });
+  });
+
+  describe('getByRevisions', () => {
+    test('selects meta and artifacts', () => {
+      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
+      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByRevisions('12345', 'abcde').then(res => {
+        expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in $1', [
+          ['12345', 'abcde']
+        ]);
+        expect(res).toEqual([row1, row2]);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByRevisions('12345', 'abcde').catch(err => {
+        expect(err).toBeInstanceOf(NotFoundError);
+      });
+    });
+  });
+
+  describe('getByRevisionRange', () => {
+    test('throw unimplemented error', () => {
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByRevisionRange('12345', 'abcde').catch(err => {
+        expect(err).toBeInstanceOf(UnimplementedError);
+      });
+    });
+  });
+
+  describe('getByTimeRange', () => {
+    test('selects meta and artifacts', () => {
+      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
+      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByTimeRange(12345, 67890, 'tacos').then(res => {
+        expect(query).toHaveBeenCalledWith(
+          'SELECT meta, artifacts FROM builds WHERE timestamp >= $1 AND timestamp <= $2 AND branch = $3 ORDER BY timestamp',
+          [12345, 67890, 'tacos']
+        );
+        expect(res).toEqual([row1, row2]);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getByTimeRange(12345, 67890, 'tacos').catch(err => {
+        expect(err).toBeInstanceOf(NotFoundError);
+      });
+    });
+  });
+
+  describe('getRecent', () => {
+    test('returns N most recent', () => {
+      const row1 = { meta: { branch: 'master', revision: '12345' }, artifacts: [] };
+      const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
+      query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getRecent(2, 'master').then(res => {
+        expect(query).toHaveBeenCalledWith(
+          'SELECT meta, artifacts FROM builds WHERE branch = $1 ORDER BY timestamp LIMIT $2',
+          ['master', 2]
+        );
+        expect(res).toEqual([row1, row2]);
+      });
+    });
+
+    test('throws with no results', () => {
+      query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
+      const queries = new Queries(Mariadb.createPool({}));
+      return queries.getRecent(undefined, 'tacos').catch(err => {
+        expect(err).toBeInstanceOf(NotFoundError);
+      });
+    });
+  });
+});

--- a/plugins/with-mariadb/src/__tests__/setup.test.ts
+++ b/plugins/with-mariadb/src/__tests__/setup.test.ts
@@ -4,7 +4,7 @@
 import * as Mariadb from 'mariadb';
 import setup from '../setup';
 
-describe('withPostgres', () => {
+describe('withMariadb setup', () => {
   let query, release, setupFn;
   beforeEach(() => {
     query = jest.fn();
@@ -15,7 +15,7 @@ describe('withPostgres', () => {
       getConnection: () => Promise.resolve({ query, release })
     }));
 
-    setupFn = setup(Mariadb.createPool({}), 'tacos');
+    setupFn = setup(Mariadb.createPool({}));
   });
 
   test('creates the table if not exists', () => {

--- a/plugins/with-mariadb/src/__tests__/setup.test.ts
+++ b/plugins/with-mariadb/src/__tests__/setup.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Mariadb from 'mariadb';
+import setup from '../setup';
+
+describe('withPostgres', () => {
+  let query, release, setupFn;
+  beforeEach(() => {
+    query = jest.fn();
+    release = jest.fn();
+    // @ts-ignore
+    jest.spyOn(Mariadb, 'createPool').mockImplementation(() => ({
+      // @ts-ignore
+      getConnection: () => Promise.resolve({ query, release })
+    }));
+
+    setupFn = setup(Mariadb.createPool({}));
+  });
+
+  test('creates the table if not exists', () => {
+    return setupFn().then(result => {
+      expect(result).toBe(true);
+      expect(query).toHaveBeenCalledWith(expect.stringMatching('CREATE TABLE IF NOT EXISTS builds'));
+    });
+  });
+
+  test('creates a multi-index', () => {
+    return setupFn().then(() => {
+      expect(query).toHaveBeenCalledWith(
+        'CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision, branch)'
+      );
+    });
+  });
+
+  test('creates an index on timestamp', () => {
+    return setupFn().then(() => {
+      expect(query).toHaveBeenCalledWith('CREATE INDEX IF NOT EXISTS timestamp ON builds (timestamp)');
+    });
+  });
+
+  test('releases the client on complete', () => {
+    return setupFn().then(() => {
+      expect(release).toHaveBeenCalled();
+    });
+  });
+
+  test('releases the client on error', () => {
+    const error = new Error('tacos');
+    query.mockReturnValueOnce(Promise.reject(error));
+    return setupFn().catch(err => {
+      expect(release).toHaveBeenCalled();
+      expect(err).toBe(error);
+    });
+  });
+});

--- a/plugins/with-mariadb/src/__tests__/setup.test.ts
+++ b/plugins/with-mariadb/src/__tests__/setup.test.ts
@@ -15,7 +15,7 @@ describe('withPostgres', () => {
       getConnection: () => Promise.resolve({ query, release })
     }));
 
-    setupFn = setup(Mariadb.createPool({}));
+    setupFn = setup(Mariadb.createPool({}), 'tacos');
   });
 
   test('creates the table if not exists', () => {

--- a/plugins/with-mariadb/src/index.ts
+++ b/plugins/with-mariadb/src/index.ts
@@ -27,7 +27,7 @@ export default function withMariadb(config: Omit<ServerConfig, 'queries'> & { ma
 
   return {
     ...config,
-    setup: setup(pool, database),
+    setup: setup(pool),
     queries: {
       build: {
         byRevision: queries.getByRevision,

--- a/plugins/with-mariadb/src/index.ts
+++ b/plugins/with-mariadb/src/index.ts
@@ -8,19 +8,26 @@ import setup from './setup';
 import { createPool, PoolConfig } from 'mariadb';
 
 config();
-
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export default function withMariadb(config: Omit<ServerConfig, 'queries'> & { mariadb: PoolConfig }): ServerConfig {
   const { mariadb: mariaConfig } = config;
+  const database = mariaConfig.database || process.env.MARIADATABASE || 'buildtracker';
 
-  const pool = createPool(mariaConfig);
+  const pool = createPool({
+    user: process.env.MARIAUSER,
+    host: process.env.MARIAHOST,
+    password: process.env.MARIAPASSWORD,
+    port: process.env.MARIAPORT ? parseInt(process.env.MARIAPORT, 10) : 3306,
+    ...mariaConfig,
+    database
+  });
 
   const queries = new Queries(pool);
 
   return {
     ...config,
-    setup: setup(pool),
+    setup: setup(pool, database),
     queries: {
       build: {
         byRevision: queries.getByRevision,

--- a/plugins/with-mariadb/src/index.ts
+++ b/plugins/with-mariadb/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { config } from 'dotenv';
+import Queries from './queries';
+import { ServerConfig } from '@build-tracker/server/src/server';
+import setup from './setup';
+import { createPool, PoolConfig } from 'mariadb';
+
+config();
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export default function withMariadb(config: Omit<ServerConfig, 'queries'> & { mariadb: PoolConfig }): ServerConfig {
+  const { mariadb: mariaConfig } = config;
+
+  const pool = createPool(mariaConfig);
+
+  const queries = new Queries(pool);
+
+  return {
+    ...config,
+    setup: setup(pool),
+    queries: {
+      build: {
+        byRevision: queries.getByRevision,
+        insert: queries.insert
+      },
+      builds: {
+        byRevisions: queries.getByRevisions,
+        byRevisionRange: queries.getByRevisionRange,
+        byTimeRange: queries.getByTimeRange,
+        recent: queries.getRecent
+      }
+    }
+  };
+}

--- a/plugins/with-mariadb/src/queries.ts
+++ b/plugins/with-mariadb/src/queries.ts
@@ -14,7 +14,7 @@ export default class Queries {
   }
 
   public getByRevision = async (revision: string): Promise<BuildStruct> => {
-    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = ?', [revision]);
     if (res.rowCount !== 1) {
       throw new NotFoundError();
     }
@@ -25,7 +25,7 @@ export default class Queries {
   public insert = async ({ meta, artifacts }: BuildStruct): Promise<string> => {
     const build = new Build(meta, artifacts);
     const res = await this._pool.query(
-      'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, $4, $5, $6)',
+      'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES (?, ?, ?, ?, ?, ?)',
       [
         build.getMetaValue('branch'),
         build.getMetaValue('revision'),
@@ -44,7 +44,7 @@ export default class Queries {
   };
 
   public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
-    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in ?', [revisions]);
     if (res.rowCount === 0) {
       throw new NotFoundError();
     }
@@ -62,7 +62,7 @@ export default class Queries {
     branch: string
   ): Promise<Array<BuildStruct>> => {
     const res = await this._pool.query(
-      'SELECT meta, artifacts FROM builds WHERE timestamp >= $1 AND timestamp <= $2 AND branch = $3 ORDER BY timestamp',
+      'SELECT meta, artifacts FROM builds WHERE timestamp >= ? AND timestamp <= ? AND branch = ? ORDER BY timestamp',
       [startTimestamp, endTimestamp, branch]
     );
     if (res.rowCount === 0) {
@@ -74,7 +74,7 @@ export default class Queries {
 
   public getRecent = async (limit: number = 20, branch: string): Promise<Array<BuildStruct>> => {
     const res = await this._pool.query(
-      'SELECT meta, artifacts FROM builds WHERE branch = $1 ORDER BY timestamp LIMIT $2',
+      'SELECT meta, artifacts FROM builds WHERE branch = ? ORDER BY timestamp LIMIT ?',
       [branch, limit]
     );
     if (res.rowCount === 0) {

--- a/plugins/with-mariadb/src/queries.ts
+++ b/plugins/with-mariadb/src/queries.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { Build as BuildStruct } from '@build-tracker/server/src/types';
+import { Pool } from 'mariadb';
+import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
+
+export default class Queries {
+  private _pool: Pool;
+
+  public constructor(pool: Pool) {
+    this._pool = pool;
+  }
+
+  public getByRevision = async (revision: string): Promise<BuildStruct> => {
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision = $1', [revision]);
+    if (res.rowCount !== 1) {
+      throw new NotFoundError();
+    }
+
+    return Promise.resolve(res.rows[0]);
+  };
+
+  public insert = async ({ meta, artifacts }: BuildStruct): Promise<string> => {
+    const build = new Build(meta, artifacts);
+    const res = await this._pool.query(
+      'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES ($1, $2, $3, $4, $5, $6)',
+      [
+        build.getMetaValue('branch'),
+        build.getMetaValue('revision'),
+        build.meta.timestamp,
+        build.getMetaValue('parentRevision'),
+        JSON.stringify(build.meta),
+        JSON.stringify(build.artifacts)
+      ]
+    );
+
+    if (res.rowCount !== 1) {
+      throw new Error('Unable to insert build');
+    }
+
+    return Promise.resolve(build.getMetaValue('revision'));
+  };
+
+  public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
+    if (res.rowCount === 0) {
+      throw new NotFoundError();
+    }
+
+    return Promise.resolve(res.rows);
+  };
+
+  public getByRevisionRange = async (startRevision: string, endRevision: string): Promise<Array<BuildStruct>> => {
+    throw new UnimplementedError(`revision range ${startRevision} - ${endRevision}`);
+  };
+
+  public getByTimeRange = async (
+    startTimestamp: number,
+    endTimestamp: number,
+    branch: string
+  ): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query(
+      'SELECT meta, artifacts FROM builds WHERE timestamp >= $1 AND timestamp <= $2 AND branch = $3 ORDER BY timestamp',
+      [startTimestamp, endTimestamp, branch]
+    );
+    if (res.rowCount === 0) {
+      throw new NotFoundError();
+    }
+
+    return Promise.resolve(res.rows);
+  };
+
+  public getRecent = async (limit: number = 20, branch: string): Promise<Array<BuildStruct>> => {
+    const res = await this._pool.query(
+      'SELECT meta, artifacts FROM builds WHERE branch = $1 ORDER BY timestamp LIMIT $2',
+      [branch, limit]
+    );
+    if (res.rowCount === 0) {
+      throw new NotFoundError();
+    }
+
+    return Promise.resolve(res.rows);
+  };
+}

--- a/plugins/with-mariadb/src/setup.ts
+++ b/plugins/with-mariadb/src/setup.ts
@@ -3,17 +3,21 @@
  */
 import { Pool } from 'mariadb';
 
-export default function setup(pool: Pool): () => Promise<boolean> {
+export default function setup(pool: Pool, database: string): () => Promise<boolean> {
   const setup = async (): Promise<boolean> => {
     const client = await pool.getConnection();
     try {
-      await client.query(`CREATE TABLE IF NOT EXISTS builds(
-  revision char(64) PRIMARY KEY NOT NULL,
-  branch char(64) NOT NULL,
-  parentRevision char(64),
-  timestamp int NOT NULL,
-  meta jsonb NOT NULL,
-  artifacts jsonb NOT NULL
+      await client.query(`
+CREATE DATABASE IF NOT EXISTS ${database};
+USE ${database};
+CREATE TABLE IF NOT EXISTS builds(
+  revision VARCHAR(64) PRIMARY KEY NOT NULL,
+  branch VARCHAR(64) NOT NULL,
+  parentRevision VARCHAR(64),
+  timestamp INT NOT NULL,
+  meta VARCHAR(1024),
+  artifacts VARCHAR(1024),
+  CHECK (meta IS NULL OR JSON_VALID(meta))
 )`);
       await client.query('CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision, branch)');
       await client.query('CREATE INDEX IF NOT EXISTS timestamp ON builds (timestamp)');

--- a/plugins/with-mariadb/src/setup.ts
+++ b/plugins/with-mariadb/src/setup.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'mariadb';
+
+export default function setup(pool: Pool): () => Promise<boolean> {
+  const setup = async (): Promise<boolean> => {
+    const client = await pool.getConnection();
+    try {
+      await client.query(`CREATE TABLE IF NOT EXISTS builds(
+  revision char(64) PRIMARY KEY NOT NULL,
+  branch char(64) NOT NULL,
+  parentRevision char(64),
+  timestamp int NOT NULL,
+  meta jsonb NOT NULL,
+  artifacts jsonb NOT NULL
+)`);
+      await client.query('CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision, branch)');
+      await client.query('CREATE INDEX IF NOT EXISTS timestamp ON builds (timestamp)');
+    } catch (err) {
+      client.release();
+      throw err;
+    }
+    client.release();
+    return Promise.resolve(true);
+  };
+  return setup;
+}
+
+module.exports = setup;

--- a/plugins/with-mariadb/src/setup.ts
+++ b/plugins/with-mariadb/src/setup.ts
@@ -3,20 +3,18 @@
  */
 import { Pool } from 'mariadb';
 
-export default function setup(pool: Pool, database: string): () => Promise<boolean> {
+export default function setup(pool: Pool): () => Promise<boolean> {
   const setup = async (): Promise<boolean> => {
     const client = await pool.getConnection();
     try {
       await client.query(`
-CREATE DATABASE IF NOT EXISTS ${database};
-USE ${database};
 CREATE TABLE IF NOT EXISTS builds(
   revision VARCHAR(64) PRIMARY KEY NOT NULL,
   branch VARCHAR(64) NOT NULL,
   parentRevision VARCHAR(64),
   timestamp INT NOT NULL,
   meta VARCHAR(1024),
-  artifacts VARCHAR(1024),
+  artifacts BLOB,
   CHECK (meta IS NULL OR JSON_VALID(meta))
 )`);
       await client.query('CREATE INDEX IF NOT EXISTS parent ON builds (revision, parentRevision, branch)');

--- a/plugins/with-mariadb/tsconfig.json
+++ b/plugins/with-mariadb/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/src/server/src/commands/seed.ts
+++ b/src/server/src/commands/seed.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as path from 'path';
+import { Argv } from 'yargs';
+import Build from '@build-tracker/build';
+import glob from 'glob';
+import { ServerConfig } from '../server';
+
+export const command = 'seed';
+
+export const description = 'Seed your database with fixture data';
+
+interface Args {
+  config: string;
+}
+
+const group = 'Seed';
+
+export const builder = (yargs): Argv<Args> =>
+  yargs.usage(`Usage: $0 ${command}`).option('config', {
+    alias: 'c',
+    coerce: v => path.join(process.cwd(), v),
+    default: 'build-tracker.config.js',
+    description: 'path to the build-tracker config file',
+    group,
+    normalize: true
+  });
+
+export const handler = async (args: Args): Promise<void> => {
+  const config = require(args.config) as ServerConfig;
+  const fixturePath = path.dirname(require.resolve('@build-tracker/fixtures'));
+
+  await config.setup();
+
+  glob.sync(`${path.join(fixturePath, 'builds')}/*.json`).forEach(async build => {
+    const buildData = require(build);
+    await config.queries.build.insert(new Build(buildData.meta, buildData.artifacts));
+  });
+
+  return Promise.resolve();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4625,6 +4625,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denque@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -8508,6 +8513,11 @@ loglevel@^1.6.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -8645,6 +8655,16 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+mariadb@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/mariadb/-/mariadb-2.0.5.tgz#cc0de6c0564c3df8fc1a639c42321032c6c6174b"
+  integrity sha512-zCf/2R3DgNRyUvdu8O48hZE+iVrHS8Q3aGrtyj6oV4st/byBltPBBM0AVFKiAEnnDqIGLkwfvxOSy11e7gbdGw==
+  dependencies:
+    denque "^1.4.0"
+    iconv-lite "^0.4.24"
+    long "^4.0.0"
+    moment-timezone "^0.5.25"
 
 markdown-escapes@^1.0.0:
   version "1.0.2"
@@ -8976,7 +8996,14 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@>=2.14.0:
+moment-timezone@^0.5.25:
+  version "0.5.25"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
+  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@>=2.14.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

For those that use MySQL/MariaDB flavors, it would be great to provide an out-of-the-box plugin

# Solution

Went with MariaDB as it seems like the more acceptable open-source flavor now. Mostly lifted from the Postgres plugin, but required a few changes. Most notably, the return values are arrays and not objects with keys of information. Blobs from the DB turn into Buffers in JS, so they need extra parsing before being returned.

Also added a couple dev modes: `yarn dev:maria` and `yarn dev:postgres`, as well as a `seed` command for the server that will drop in data from the fixtures package.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
