### PR TITLE
[docs] fix broken link

### DIFF
--- a/docs/website/core/Footer.js
+++ b/docs/website/core/Footer.js
@@ -33,7 +33,7 @@ class Footer extends React.Component {
             <h5>Docs</h5>
             <a href={this.docUrl('installation.html', language)}>Getting Started</a>
             <a href={this.docUrl('guides.html', language)}>Guides</a>
-            <a href={this.docUrl('plugins.html', language)}>Plugins</a>
+            <a href={this.docUrl('plugins/plugins.html', language)}>Plugins</a>
           </div>
           <div>
             <h5>Community</h5>


### PR DESCRIPTION
# Problem
The website footer has two broken links: plugins and guides. This fixes plugins. I don't know how Guides should be handled, since I found no guide(s) in the nearby folders.