### PR TITLE
[blog] update 1.0.0 blog post as roadmap

### DIFF
--- a/docs/website/blog/2019-03-22-version-1.md
+++ b/docs/website/blog/2019-03-22-version-1.md
@@ -1,7 +1,37 @@
 ---
-title: Build Tracker v1.0.0
+title: Build Tracker v1.0.0 Roadmap
 author: Paul Armstrong
 authorURL: http://twitter.com/paularmstrong
 ---
 
-It's finally here
+It's finally here! Well, sort of.
+
+Build Tracker is currently testing at v1.0.0-alpha.x. Much of the 1.0.0 API is finalized, but there are a few [features and bugs](https://github.com/paularmstrong/build-tracker/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.0.0) to get finished up before it can be declared final.
+
+In general, the main pieces currently missing from the 1.0.0 branch that were either available in 0.x.x or highly desired:
+
+- [Routing/Linking](https://github.com/paularmstrong/build-tracker/issues/43): In order to have proper direct-linking into the application from PR comments and other integrations, we need a way to directly link to specific Build comparisons.
+- [Tooltips on charts](https://github.com/paularmstrong/build-tracker/issues/12) While hovering over the chart, it would be helpful to quickly show whether a build triggered any budget warnings or errors against its previous build.
+- [Validation on build insert](https://github.com/paularmstrong/build-tracker/issues/25)
+- [Example Github integrations](https://github.com/paularmstrong/build-tracker/issues/57)
+
+## FAQs
+
+### Wait, there's a 0.x branch available?
+
+Yep! Build Tracker has been available for a long time, but wasn't well priorized. The biggest thing that 0.x lacked was clear budget definitions. The 1.0.0 version of Build Tracker is a complete rewrite of the original source.
+
+It is _not recommended_ to get started using any of the 0.x versions, as the API is not compatible with 1.x.
+
+### How do I get involved?
+
+It's so awesome that you want to help! Build Tracker is a labor of love and I don't get anything out of it, other than satisfaction that it helps people with the performance budgeting. Any assistance that you provide helps me have more time to not be at the computer 🚴🏼‍♂️🤣
+
+To get set up, first start with the [Contributing docs](/docs/contributing) and familiarize yourself with the community [Code of Conduct](https://github.com/paularmstrong/build-tracker/blob/next/CODE_OF_CONDUCT.md).
+
+If you have any issues getting started and you're not sure what you should work on, it's actually a great chance to help others by fixing the docs!
+
+### How will I know when 1.0.0 is ready?
+
+- Watch the [Github repo](https://github.com/paularmstrong/build-tracker)
+- You can track the progress on the [v1.0.0 Milestone](https://github.com/paularmstrong/build-tracker/milestone/1)


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

The 1.0.0 blog post is lacking anything useful

# Solution

Convert it to an announcement/roadmap information post

Fixes #61 