### PR TITLE
[chore] Remove react-native-testing-library

### DIFF
--- a/src/app/src/components/DatePicker.tsx
+++ b/src/app/src/components/DatePicker.tsx
@@ -13,6 +13,7 @@ import getDaysInMonth from 'date-fns/get_days_in_month';
 import isSameDay from 'date-fns/is_same_day';
 import isSameMonth from 'date-fns/is_same_month';
 import isToday from 'date-fns/is_today';
+import isValidDate from 'date-fns/is_valid';
 import React from 'react';
 import RelativeModal from './RelativeModal';
 import startOfMonth from 'date-fns/start_of_month';
@@ -38,7 +39,13 @@ const DatePicker = (props: Props): React.ReactElement => {
     selectedDate = startOfToday()
   } = props;
 
+  const [propSelectedDate, setPropSelectedDate] = React.useState<Date>(selectedDate);
   const [currentMonth, setCurrentMonth] = React.useState<Date>(startOfMonth(selectedDate));
+
+  if (isValidDate(selectedDate) && !isSameDay(propSelectedDate, selectedDate)) {
+    setPropSelectedDate(selectedDate);
+    setCurrentMonth(startOfMonth(selectedDate));
+  }
 
   const daysInMonth = getDaysInMonth(currentMonth);
   const startDate = startOfWeek(startOfMonth(currentMonth), { weekStartsOn: 0 });

--- a/src/app/src/components/Drawer.tsx
+++ b/src/app/src/components/Drawer.tsx
@@ -38,6 +38,7 @@ class Drawer extends React.Component<Props, State> {
         {
           // @ts-ignore pointerEvents is web-only
           <TouchableOpacity
+            accessibilityLabel="Dismiss navigation"
             activeOpacity={0.32}
             onPress={this._hideDrawer}
             pointerEvents={forceShow ? 'box-only' : 'none'}

--- a/src/app/src/components/__tests__/BuildInfo.test.tsx
+++ b/src/app/src/components/__tests__/BuildInfo.test.tsx
@@ -8,19 +8,20 @@ import Comparator from '@build-tracker/comparator';
 import mockStore from '../../store/mock';
 import React from 'react';
 import { StoreContext } from 'redux-react-hook';
-import { fireEvent, render } from 'react-native-testing-library';
+import { fireEvent, render } from '@testing-library/react';
 
 const build = new Build({ branch: 'master', revision: '1234565', parentRevision: 'abcdef', timestamp: 123 }, []);
 
 describe('BuildInfo', () => {
   test('can be closed', () => {
     const focusRevisionSpy = jest.spyOn(Actions, 'setFocusedRevision');
-    const { getByProps } = render(
+    const { getByRole } = render(
       <StoreContext.Provider value={mockStore({ comparator: new Comparator({ builds: [build] }) })}>
         <BuildInfo focusedRevision="1234565" />
       </StoreContext.Provider>
     );
-    fireEvent.press(getByProps({ title: 'Close' }));
+    fireEvent.touchStart(getByRole('button'));
+    fireEvent.touchEnd(getByRole('button'));
     expect(focusRevisionSpy).toHaveBeenCalledWith(undefined);
   });
 });

--- a/src/app/src/components/__tests__/Button.test.tsx
+++ b/src/app/src/components/__tests__/Button.test.tsx
@@ -3,16 +3,15 @@
  */
 import Button from '../Button';
 import React from 'react';
-import Ripple from '../Ripple';
-import { fireEvent, render } from 'react-native-testing-library';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Button', () => {
   describe('icon', () => {
     test('renders an icon before the title', () => {
-      const FakeIcon = (): React.ReactElement => <div />;
-      const { getByType } = render(<Button icon={FakeIcon} title="tacos" />);
-      expect(getByType(FakeIcon)).not.toBeUndefined();
+      const FakeIcon = (): React.ReactElement => <div data-testid="icon" />;
+      const { getByTestId, queryAllByText } = render(<Button icon={FakeIcon} title="tacos" />);
+      expect(getByTestId('icon')).not.toBeUndefined();
+      expect(queryAllByText('tacos')).toHaveLength(1);
     });
 
     test('does not render the title when iconOnly', () => {
@@ -25,15 +24,17 @@ describe('Button', () => {
   describe('onPress', () => {
     test('property is called when button is pressed', () => {
       const handlePress = jest.fn();
-      const { getByType } = render(<Button onPress={handlePress} title="tacos" />);
-      fireEvent.press(getByType(TouchableOpacity));
+      const { getByRole } = render(<Button onPress={handlePress} title="tacos" />);
+      fireEvent.touchStart(getByRole('button'));
+      fireEvent.touchEnd(getByRole('button'));
       expect(handlePress).toHaveBeenCalled();
     });
 
     test('property is not called when disabled', () => {
       const handlePress = jest.fn();
-      const { getByType } = render(<Button disabled onPress={handlePress} title="tacos" />);
-      fireEvent.press(getByType(TouchableOpacity));
+      const { getByRole } = render(<Button disabled onPress={handlePress} title="tacos" />);
+      fireEvent.touchStart(getByRole('button'));
+      fireEvent.touchEnd(getByRole('button'));
       expect(handlePress).not.toHaveBeenCalled();
     });
   });
@@ -41,36 +42,29 @@ describe('Button', () => {
   describe('styles', () => {
     describe('active', () => {
       test('sets active styles while press inside', () => {
-        const { getByType } = render(<Button title="tacos" type="raised" />);
-        fireEvent(getByType(TouchableOpacity), 'pressIn', { nativeEvent: { locationX: 0, locationY: 0 } });
-        expect(StyleSheet.flatten(getByType(Ripple).props.style)).toMatchObject({
-          shadowOffset: { width: 0, height: 2 },
-          shadowRadius: 3
-        });
+        const { getByRole } = render(<Button title="tacos" type="raised" />);
+        fireEvent.touchStart(getByRole('button'), { locationX: 0, locationY: 0 });
+        // @ts-ignore
+        expect(getByRole('button').firstChild.style.boxShadow).toEqual('0px 2px 3px rgba(0,0,0,0.30)');
+        fireEvent.touchEnd(getByRole('button'), { locationX: 0, locationY: 0 });
       });
 
       test('removes active styles after press out', () => {
-        const { getByType } = render(<Button title="tacos" type="raised" />);
-        fireEvent(getByType(TouchableOpacity), 'pressIn', { nativeEvent: { locationX: 0, locationY: 0 } });
-        fireEvent(getByType(TouchableOpacity), 'pressOut', { nativeEvent: { locationX: 0, locationY: 0 } });
-        expect(StyleSheet.flatten(getByType(Ripple).props.style)).toMatchObject({
-          shadowOffset: { width: 0, height: 2 },
-          shadowRadius: 5
-        });
+        const { getByRole } = render(<Button title="tacos" type="raised" />);
+        fireEvent.touchStart(getByRole('button'), { locationX: 0, locationY: 0 });
+        fireEvent.touchEnd(getByRole('button'), { locationX: 0, locationY: 0 });
+        // @ts-ignore
+        expect(getByRole('button').firstChild.style.boxShadow).toEqual('0px 2px 5px rgba(0,0,0,0.30)');
       });
 
       test('when disabled, does not set active styles', () => {
-        const { getByType } = render(<Button disabled title="tacos" type="raised" />);
-        fireEvent(getByType(TouchableOpacity), 'pressIn', { nativeEvent: { locationX: 0, locationY: 0 } });
-        expect(StyleSheet.flatten(getByType(Ripple).props.style)).toMatchObject({
-          shadowOffset: { width: 0, height: 2 },
-          shadowRadius: 5
-        });
-        fireEvent(getByType(TouchableOpacity), 'pressOut', { nativeEvent: { locationX: 0, locationY: 0 } });
-        expect(StyleSheet.flatten(getByType(Ripple).props.style)).toMatchObject({
-          shadowOffset: { width: 0, height: 2 },
-          shadowRadius: 5
-        });
+        const { getByRole } = render(<Button disabled title="tacos" type="raised" />);
+        fireEvent.touchStart(getByRole('button'), { locationX: 0, locationY: 0 });
+        // @ts-ignore
+        expect(getByRole('button').firstChild.style.boxShadow).toEqual('0px 2px 5px rgba(0,0,0,0.30)');
+        fireEvent.touchEnd(getByRole('button'), { locationX: 0, locationY: 0 });
+        // @ts-ignore
+        expect(getByRole('button').firstChild.style.boxShadow).toEqual('0px 2px 5px rgba(0,0,0,0.30)');
       });
     });
   });

--- a/src/app/src/components/__tests__/DatePicker.test.tsx
+++ b/src/app/src/components/__tests__/DatePicker.test.tsx
@@ -4,7 +4,7 @@
 import DatePicker from '../DatePicker';
 import React from 'react';
 import { View } from 'react-native';
-import { fireEvent, render } from 'react-native-testing-library';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('DatePicker', () => {
   let viewRef;
@@ -15,47 +15,68 @@ describe('DatePicker', () => {
 
   describe('minDate', () => {
     test('disables days before the minDate', () => {
-      const { queryAllByProps } = render(
-        <DatePicker minDate={new Date(2019, 2, 26)} relativeTo={viewRef} selectedDate={new Date(2019, 2, 27)} />
+      const handleSelect = jest.fn();
+      const { getByLabelText } = render(
+        <DatePicker
+          minDate={new Date(2019, 2, 26)}
+          onSelect={handleSelect}
+          relativeTo={viewRef}
+          selectedDate={new Date(2019, 2, 27)}
+        />
       );
-      expect(queryAllByProps({ accessibilityLabel: '2019-03-25', disabled: true, type: 'text' })).toHaveLength(1);
+      const beforeDay = getByLabelText('2019-03-25');
+      fireEvent.touchStart(beforeDay);
+      fireEvent.touchEnd(beforeDay);
+      expect(handleSelect).not.toHaveBeenCalled();
     });
   });
 
   describe('maxDate', () => {
     test('disables days after the maxDate', () => {
-      const { queryAllByProps } = render(
-        <DatePicker maxDate={new Date(2019, 2, 26)} relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />
+      const handleSelect = jest.fn();
+      const { getByLabelText } = render(
+        <DatePicker
+          maxDate={new Date(2019, 2, 26)}
+          onSelect={handleSelect}
+          relativeTo={viewRef}
+          selectedDate={new Date(2019, 2, 23)}
+        />
       );
-      expect(queryAllByProps({ accessibilityLabel: '2019-03-27', disabled: true, type: 'text' })).toHaveLength(1);
+      const afterDay = getByLabelText('2019-03-27');
+      fireEvent.touchStart(afterDay);
+      fireEvent.touchEnd(afterDay);
+      expect(handleSelect).not.toHaveBeenCalled();
     });
   });
 
   describe('selectedDate', () => {
     test('sets a different style for the selected date', () => {
-      const { queryAllByProps } = render(<DatePicker relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />);
-      expect(queryAllByProps({ accessibilityLabel: '2019-03-23', disabled: false, type: 'unelevated' })).toHaveLength(
-        1
-      );
+      const { getByLabelText } = render(<DatePicker relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />);
+      const today = getByLabelText('2019-03-23');
+      const yesterday = getByLabelText('2019-03-22');
+      // @ts-ignore
+      expect(yesterday.style).not.toEqual(today.style);
     });
   });
 
   describe('navigation', () => {
     test('next month moves forward', () => {
-      const { getByProps, queryAllByText } = render(
+      const { getByLabelText, queryAllByText } = render(
         <DatePicker relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />
       );
       expect(queryAllByText('March')).toHaveLength(1);
-      fireEvent.press(getByProps({ title: 'Next month' }));
+      fireEvent.touchStart(getByLabelText('Next month'));
+      fireEvent.touchEnd(getByLabelText('Next month'));
       expect(queryAllByText('April')).toHaveLength(1);
     });
 
     test('previous month moves forward', () => {
-      const { getByProps, queryAllByText } = render(
+      const { getByLabelText, queryAllByText } = render(
         <DatePicker relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />
       );
       expect(queryAllByText('March')).toHaveLength(1);
-      fireEvent.press(getByProps({ title: 'Previous month' }));
+      fireEvent.touchStart(getByLabelText('Previous month'));
+      fireEvent.touchEnd(getByLabelText('Previous month'));
       expect(queryAllByText('February')).toHaveLength(1);
     });
   });
@@ -63,10 +84,11 @@ describe('DatePicker', () => {
   describe('onSelect', () => {
     test('fires when day button is pressed', () => {
       const handleSelect = jest.fn();
-      const { getByProps } = render(
+      const { getByLabelText } = render(
         <DatePicker onSelect={handleSelect} relativeTo={viewRef} selectedDate={new Date(2019, 2, 23)} />
       );
-      fireEvent.press(getByProps({ accessibilityLabel: '2019-03-24', disabled: false }));
+      fireEvent.touchStart(getByLabelText('2019-03-24'));
+      fireEvent.touchEnd(getByLabelText('2019-03-24'));
       expect(handleSelect).toHaveBeenCalledWith(new Date(2019, 2, 24));
     });
   });

--- a/src/app/src/components/__tests__/DateTextField.test.tsx
+++ b/src/app/src/components/__tests__/DateTextField.test.tsx
@@ -1,77 +1,88 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import DatePicker from '../DatePicker';
 import DateTextField from '../DateTextField';
+import formatDate from 'date-fns/format';
 import React from 'react';
-import { TextInput } from 'react-native';
-import { fireEvent, flushMicrotasksQueue, render } from 'react-native-testing-library';
+import startOfToday from 'date-fns/start_of_today';
+import { fireEvent, render, waitForElement } from '@testing-library/react';
+
+const thisMonth = formatDate(new Date(), 'MMMM');
 
 describe('DateTextField', () => {
   describe('on press tab key', () => {
     test('hides the date picker', async () => {
-      const { getByType, queryAllByType } = render(<DateTextField label="foobar" onSet={jest.fn()} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      expect(queryAllByType(DatePicker)).toHaveLength(1);
-      fireEvent(getByType(TextInput), 'keyPress', { key: 'Tab' });
-      expect(queryAllByType(DatePicker)).toHaveLength(0);
+      const { getByLabelText, queryAllByText } = render(<DateTextField label="foobar" onSet={jest.fn()} />);
+
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      expect(queryAllByText(thisMonth)).toHaveLength(1);
+      fireEvent.keyDown(getByLabelText('foobar'), { key: 'Tab' });
+      fireEvent.keyUp(getByLabelText('foobar'), { key: 'Tab' });
+      expect(queryAllByText(thisMonth)).toHaveLength(0);
     });
   });
 
   describe('onChangeText', () => {
     test('calls onSet for a valid date', async () => {
       const handleSet = jest.fn();
-      const { getByType } = render(<DateTextField label="foobar" onSet={handleSet} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      fireEvent(getByType(TextInput), 'changeText', '2019-03-26');
+      const { getByLabelText, queryAllByText } = render(<DateTextField label="foobar" onSet={handleSet} />);
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      fireEvent.change(getByLabelText('foobar'), { target: { value: '2019-03-26' } });
       expect(handleSet).toHaveBeenCalledWith(new Date('2019-03-26'));
-      expect(getByType(DatePicker).props.selectedDate).toEqual(new Date('2019-03-26'));
+      expect(getByLabelText('2019-03-26')).not.toBeUndefined();
     });
 
     test('does not call onSet for invalid date', async () => {
       const handleSet = jest.fn();
-      const { getByType } = render(<DateTextField label="foobar" onSet={handleSet} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      fireEvent(getByType(TextInput), 'changeText', '2019-0');
+      const { getByLabelText, queryAllByText } = render(<DateTextField label="foobar" onSet={handleSet} />);
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      fireEvent.change(getByLabelText('foobar'), { target: { value: '2019-0' } });
       expect(handleSet).not.toHaveBeenCalled();
-      expect(getByType(DatePicker).props.selectedDate).toBeUndefined();
+      const today = formatDate(new Date(), 'YYYY-MM-DD');
+      expect(getByLabelText(today)).not.toBeUndefined();
     });
   });
 
   describe('when selecting a date', () => {
     test('hides the date picker', async () => {
-      const { getByType, queryAllByType } = render(<DateTextField label="foobar" onSet={jest.fn()} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      expect(queryAllByType(DatePicker)).toHaveLength(1);
+      const { getByLabelText, queryAllByText } = render(<DateTextField label="foobar" onSet={jest.fn()} />);
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      expect(queryAllByText(thisMonth)).toHaveLength(1);
 
-      fireEvent(getByType(DatePicker), 'select', new Date());
-      expect(queryAllByType(DatePicker)).toHaveLength(0);
+      const today = formatDate(new Date(), 'YYYY-MM-DD');
+      fireEvent.touchStart(getByLabelText(today));
+      fireEvent.touchEnd(getByLabelText(today));
+
+      expect(queryAllByText(thisMonth)).toHaveLength(0);
     });
 
     test('calls onSet', async () => {
       const handleSet = jest.fn();
-      const { getByType, queryAllByType } = render(<DateTextField label="foobar" onSet={handleSet} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      expect(queryAllByType(DatePicker)).toHaveLength(1);
+      const { getByLabelText, queryAllByText } = render(<DateTextField label="foobar" onSet={handleSet} />);
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      expect(queryAllByText(thisMonth)).toHaveLength(1);
 
-      const now = new Date();
-      fireEvent(getByType(DatePicker), 'select', now);
-      expect(handleSet).toHaveBeenCalledWith(now);
+      const today = formatDate(startOfToday(), 'YYYY-MM-DD');
+      fireEvent.touchStart(getByLabelText(today));
+      fireEvent.touchEnd(getByLabelText(today));
+      expect(handleSet).toHaveBeenCalledWith(startOfToday());
     });
 
     test('sets the text field value', async () => {
-      const { getByType, queryAllByType } = render(<DateTextField label="foobar" onSet={jest.fn()} />);
-      fireEvent(getByType(TextInput), 'focus');
-      await flushMicrotasksQueue();
-      expect(queryAllByType(DatePicker)).toHaveLength(1);
+      const { getByLabelText, queryAllByText, getByDisplayValue } = render(<DateTextField label="foobar" />);
+      fireEvent.focus(getByLabelText('foobar'));
+      await waitForElement(() => queryAllByText(thisMonth));
+      expect(queryAllByText(thisMonth)).toHaveLength(1);
 
-      fireEvent(getByType(DatePicker), 'select', new Date(2019, 2, 26));
-      expect(getByType(TextInput).props.value).toBe('2019-03-26');
+      const today = formatDate(startOfToday(), 'YYYY-MM-DD');
+      fireEvent.touchStart(getByLabelText(today));
+      fireEvent.touchEnd(getByLabelText(today));
+      expect(getByDisplayValue(today)).not.toBeUndefined();
     });
   });
 });

--- a/src/app/src/components/__tests__/Divider.test.tsx
+++ b/src/app/src/components/__tests__/Divider.test.tsx
@@ -1,20 +1,20 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import * as Theme from '../../theme';
 import Divider from '../Divider';
 import React from 'react';
-import { render } from 'react-native-testing-library';
-import { StyleSheet, View } from 'react-native';
+import { render } from '@testing-library/react';
 
 describe('Divider', () => {
   test('renders a simple divider', () => {
-    const { getByType } = render(<Divider />);
-    expect(StyleSheet.flatten(getByType(View).props.style)).toMatchObject({ backgroundColor: Theme.Color.Gray20 });
+    const { container } = render(<Divider />);
+    // @ts-ignore
+    expect(container.firstChild.style.backgroundColor).toEqual('rgb(212, 212, 212)');
   });
 
   test('renders a divider with the given color', () => {
-    const { getByType } = render(<Divider color="red" />);
-    expect(StyleSheet.flatten(getByType(View).props.style)).toMatchObject({ backgroundColor: 'red' });
+    const { container } = render(<Divider color="red" />);
+    // @ts-ignore
+    expect(container.firstChild.style.backgroundColor).toEqual('rgb(255, 0, 0)');
   });
 });

--- a/src/app/src/components/__tests__/Drawer.test.tsx
+++ b/src/app/src/components/__tests__/Drawer.test.tsx
@@ -3,49 +3,48 @@
  */
 import Drawer from '../Drawer';
 import React from 'react';
-import { fireEvent, render } from 'react-native-testing-library';
-import { ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Drawer', () => {
   describe('hidden', () => {
     test('is hidden initially', () => {
-      const { getByType } = render(
+      const { getByRole } = render(
         <Drawer hidden>
           <div />
         </Drawer>
       );
-      expect(getByType(ScrollView).props['aria-hidden']).toBe(true);
-      const styles = StyleSheet.flatten(getByType(ScrollView).props.style);
-      expect(styles).toMatchObject({ maxWidth: 300, left: -300, position: 'absolute' });
+      expect(getByRole('nav').getAttribute('aria-hidden')).toBe('true');
     });
   });
 
   describe('show', () => {
     test('makes the drawer visible', () => {
-      const { getByType } = render(
-        <Drawer hidden>
+      const ref = React.createRef<Drawer>();
+      const { getByRole } = render(
+        // @ts-ignore
+        <Drawer hidden ref={ref}>
           <div />
         </Drawer>
       );
-      getByType(Drawer).instance.show();
-      expect(getByType(ScrollView).props['aria-hidden']).toBe(false);
-      const styles = StyleSheet.flatten(getByType(ScrollView).props.style);
-      expect(styles).toMatchObject({ maxWidth: 300, left: 0 });
+      ref.current.show();
+      expect(getByRole('nav').getAttribute('aria-hidden')).toBe('false');
     });
   });
 
   describe('scrim', () => {
-    test('hides the drawer when presse3d', () => {
-      const { getByType } = render(
-        <Drawer hidden>
+    test('hides the drawer when pressed', () => {
+      const ref = React.createRef<Drawer>();
+      const { getByLabelText, getByRole } = render(
+        // @ts-ignore
+        <Drawer hidden ref={ref}>
           <div />
         </Drawer>
       );
-      getByType(Drawer).instance.show();
-      fireEvent.press(getByType(TouchableOpacity));
-      expect(getByType(ScrollView).props['aria-hidden']).toBe(true);
-      const styles = StyleSheet.flatten(getByType(ScrollView).props.style);
-      expect(styles).toMatchObject({ maxWidth: 300, left: -300, position: 'absolute' });
+      ref.current.show();
+
+      fireEvent.touchStart(getByLabelText('Dismiss navigation'));
+      fireEvent.touchEnd(getByLabelText('Dismiss navigation'));
+      expect(getByRole('nav').getAttribute('aria-hidden')).toBe('true');
     });
   });
 });

--- a/src/app/src/components/__tests__/DrawerLink.test.tsx
+++ b/src/app/src/components/__tests__/DrawerLink.test.tsx
@@ -1,26 +1,30 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import * as Theme from '../../theme';
 import DrawerLink from '../DrawerLink';
 import HeartIcon from '../../icons/Heart';
 import React from 'react';
-import { fireEvent, render } from 'react-native-testing-library';
-import { StyleSheet, Text } from 'react-native';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('DrawerLink', () => {
   describe('icon', () => {
     test('does not render an icon', () => {
-      const { getByType } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
-      expect(getByType(Text).props.children.props.children).toHaveLength(2);
-      expect(getByType(Text).props.children.props.children).toEqual([null, 'tacos']);
+      const { getByRole } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
+      expect(getByRole('link').firstChild).toMatchInlineSnapshot(`
+        <div
+          class="css-text-76zvg2"
+          dir="auto"
+          style="font-size: 1rem;"
+        >
+          tacos
+        </div>
+      `);
     });
 
     test('renders the icon', () => {
-      const { queryAllByType } = render(
-        <DrawerLink href="https://build-tracker.local" icon={HeartIcon} text="tacos" />
-      );
-      expect(queryAllByType(HeartIcon)).toHaveLength(1);
+      const { getByRole } = render(<DrawerLink href="https://build-tracker.local" icon={HeartIcon} text="tacos" />);
+      // @ts-ignore
+      expect(getByRole('link').firstChild.firstChild.tagName).toEqual('svg');
     });
   });
 
@@ -30,27 +34,21 @@ describe('DrawerLink', () => {
     });
 
     test('adds a bg color', () => {
-      const { getByProps } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
-      const root = getByProps({ accessibilityRole: 'link' });
-      expect(StyleSheet.flatten(root.props.style)).not.toMatchObject({
-        backgroundColor: expect.any(String)
-      });
-      fireEvent(root, 'mouseEnter');
-      expect(StyleSheet.flatten(root.props.style)).toMatchObject({
-        backgroundColor: Theme.Color.Primary00
-      });
+      const { getByRole } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
+      const link = getByRole('link');
+      expect(link.style.backgroundColor).toEqual('');
+      fireEvent.mouseEnter(link);
+      expect(link.style.backgroundColor).toEqual('rgb(199, 235, 255)');
     });
 
     test('changes font color', () => {
-      const { getByType } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
-      const root = getByType(Text);
-      expect(StyleSheet.flatten(root.props.style)).not.toMatchObject({
-        color: expect.any(String)
-      });
-      fireEvent(root, 'mouseEnter');
-      expect(StyleSheet.flatten(root.props.style)).toMatchObject({
-        color: Theme.Color.Primary40
-      });
+      const { getByRole } = render(<DrawerLink href="https://build-tracker.local" text="tacos" />);
+      const link = getByRole('link');
+      // @ts-ignore
+      expect(link.firstChild.style.color).toEqual('');
+      fireEvent.mouseEnter(link);
+      // @ts-ignore
+      expect(link.firstChild.style.color).toEqual('rgb(18, 52, 108)');
     });
   });
 });

--- a/src/app/src/components/__tests__/EmptyState.test.tsx
+++ b/src/app/src/components/__tests__/EmptyState.test.tsx
@@ -3,7 +3,7 @@
  */
 import EmptyState from '../EmptyState';
 import React from 'react';
-import { render } from 'react-native-testing-library';
+import { render } from '@testing-library/react';
 
 describe('EmptyState', () => {
   test('renders a message', () => {

--- a/src/app/src/components/__tests__/Hoverable.test.tsx
+++ b/src/app/src/components/__tests__/Hoverable.test.tsx
@@ -4,7 +4,7 @@
 import Hoverable from '../Hoverable';
 import React from 'react';
 import { View } from 'react-native';
-import { fireEvent, render } from 'react-native-testing-library';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Hoverable', () => {
   describe('when hover is supported', () => {
@@ -18,7 +18,7 @@ describe('Hoverable', () => {
         const hoverFn = jest.fn(() => <View testID="foo" />);
         const TestHover = (): React.ReactElement => <Hoverable>{hoverFn}</Hoverable>;
         const { getByTestId } = render(<TestHover />);
-        fireEvent(getByTestId('foo'), 'mouseEnter');
+        fireEvent.mouseEnter(getByTestId('foo'));
         expect(hoverFn).toHaveBeenCalledWith(true);
       });
 
@@ -26,8 +26,8 @@ describe('Hoverable', () => {
         const hoverFn = jest.fn(() => <View testID="foo" />);
         const TestHover = (): React.ReactElement => <Hoverable>{hoverFn}</Hoverable>;
         const { getByTestId } = render(<TestHover />);
-        fireEvent(getByTestId('foo'), 'mouseEnter');
-        fireEvent(getByTestId('foo'), 'mouseLeave');
+        fireEvent.mouseEnter(getByTestId('foo'));
+        fireEvent.mouseLeave(getByTestId('foo'));
         expect(hoverFn).toHaveBeenNthCalledWith(1, false);
         expect(hoverFn).toHaveBeenNthCalledWith(2, true);
         expect(hoverFn).toHaveBeenNthCalledWith(3, false);
@@ -43,7 +43,7 @@ describe('Hoverable', () => {
           </Hoverable>
         );
         const { getByTestId } = render(<TestHover />);
-        fireEvent(getByTestId('foo'), 'mouseEnter');
+        fireEvent.mouseEnter(getByTestId('foo'));
         expect(hoverFn).toHaveBeenCalled();
       });
 
@@ -55,8 +55,8 @@ describe('Hoverable', () => {
           </Hoverable>
         );
         const { getByTestId } = render(<TestHover />);
-        fireEvent(getByTestId('foo'), 'mouseEnter');
-        fireEvent(getByTestId('foo'), 'mouseLeave');
+        fireEvent.mouseEnter(getByTestId('foo'));
+        fireEvent.mouseLeave(getByTestId('foo'));
         expect(hoverFn).toHaveBeenCalled();
       });
     });
@@ -72,7 +72,7 @@ describe('Hoverable', () => {
       const hoverFn = jest.fn(() => <View testID="foo" />);
       const TestHover = (): React.ReactElement => <Hoverable>{hoverFn}</Hoverable>;
       const { getByTestId } = render(<TestHover />);
-      fireEvent(getByTestId('foo'), 'mouseEnter');
+      fireEvent.mouseEnter(getByTestId('foo'));
       expect(hoverFn).not.toHaveBeenCalledWith(true);
     });
 
@@ -80,8 +80,8 @@ describe('Hoverable', () => {
       const hoverFn = jest.fn(() => <View testID="foo" />);
       const TestHover = (): React.ReactElement => <Hoverable>{hoverFn}</Hoverable>;
       const { getByTestId } = render(<TestHover />);
-      fireEvent(getByTestId('foo'), 'mouseEnter');
-      fireEvent(getByTestId('foo'), 'mouseLeave');
+      fireEvent.mouseEnter(getByTestId('foo'));
+      fireEvent.mouseLeave(getByTestId('foo'));
       expect(hoverFn).not.toHaveBeenCalledWith(true);
     });
   });


### PR DESCRIPTION
# Problem

`react-native-testing-library` is somewhat unnecessary. The newest version has breaking changes and it's confusing to switch between `@testing-library/react` and `react-native-testing-library`, sometimes mixing the two in the same test files

# Solution

I think it would be best to remove `react-native-testing-library` from the `@build-tracker/app` tests in favor of `@testing-library/react`

Resolves #68 

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
