### PR TITLE
fix(@build-tracker/cli): Use relative path for bin script

### DIFF
--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -6,7 +6,7 @@
   "repository": "git@github.com:paularmstrong/build-tracker.git",
   "license": "MIT",
   "bin": {
-    "bt-cli": "dist/bin"
+    "bt-cli": "./dist/bin.js"
   },
   "main": "dist",
   "scripts": {


### PR DESCRIPTION
# Problem

I couldn't install `@build-tracker/cli` using NPM due to the following error:

```
ENOENT: no such file or directory, chmod '/Users/.../node_modules/@build-tracker/cli/dist/bin'
This is related to npm not being able to find a file.
```

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

After small investigation it figure out that the problem was with `bin` path in package.json.
According to [NPM documentation](https://docs.npmjs.com/files/package.json#bin) it's better to use relative path with file extension.