### PR TITLE
fix(bt-server): fix PATH reference to Node.js

### DIFF
--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env Node
+#!/usr/bin/env node
 /**
  * Copyright (c) 2019 Paul Armstrong
  */


### PR DESCRIPTION
# Problem

We were running into an error with the environment with the uppercase `#!/usr/bin/env Node`:

```
bt-server_1  | /usr/bin/env: 'Node': No such file or directory
bt-server_1  | error Command failed with exit code 127.
```

# Solution
I believe changing this to `#!/usr/bin/env node` will fix this on all environments.