### PR TITLE
chore(package): Add implicit dependencies to `dependencies`

### DIFF
--- a/plugins/with-mariadb/package.json
+++ b/plugins/with-mariadb/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@build-tracker/api-errors": "^1.0.0-alpha.3",
+    "@build-tracker/build": "^1.0.0-alpha.3",
     "dotenv": "^7.0.0",
     "mariadb": "^2.0.5"
   },

--- a/plugins/with-postgres/package.json
+++ b/plugins/with-postgres/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@build-tracker/api-errors": "^1.0.0-alpha.3",
+    "@build-tracker/build": "^1.0.0-alpha.3",
     "dotenv": "^7.0.0",
     "pg": "^7.8.2"
   },

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -14,11 +14,11 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
+    "@build-tracker/formatting": "^1.0.0-alpha.3",
     "markdown-table": "^1.1.2"
   },
   "devDependencies": {
     "@build-tracker/build": "^1.0.0-alpha.3",
-    "@build-tracker/formatting": "^1.0.0-alpha.3",
     "@build-tracker/types": "^1.0.0-alpha.3"
   },
   "publishConfig": {

--- a/src/formatting/package.json
+++ b/src/formatting/package.json
@@ -15,5 +15,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@build-tracker/types": "^1.0.0-alpha.3"
+  },
   "gitHead": "6c5cd0948348d6eda531eeb0178c054a253a6ec7"
 }

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -20,10 +20,12 @@
     "@build-tracker/app": "^1.0.0-alpha.3",
     "@build-tracker/build": "^1.0.0-alpha.3",
     "@build-tracker/comparator": "^1.0.0-alpha.3",
+    "@build-tracker/fixtures": "^1.0.0-alpha.3",
     "@build-tracker/formatting": "^1.0.0-alpha.3",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "express-pino-logger": "^4.0.0",
+    "glob": "^7.1.3",
     "helmet": "^3.15.1",
     "pino": "^5.11.1",
     "yargs": "^13.2.1"


### PR DESCRIPTION
# Problem

yarn v2 requires all dependencies to be explicitly declared in `dependencies` of `package.json`. Otherwise it fails with e.g.

```bash
Error: A package is trying to access another package without the second one being listed as a dependency of the first one

Required package: @build-tracker/build (via "@build-tracker/build")
Required by: @build-tracker/plugin-with-postgres@npm:1.0.0-alpha.3 
```

Even with 1.x you get missing module errors for `@build-tracker/types` and `glob`

# Solution

Added any dependency that got reported when running `yarn bt-server run`.

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage) @eps1lon: I guess switching to yarn v2 is not an option.
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- ~[ ] 📖 Update relevant documentation~
