### PR TITLE
[chore] split up PR and Push actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,8 +3,8 @@ name: On pull request
 on: pull_request
 
 jobs:
-  test:
-    name: Test changes
+  housekeeping:
+    name: Housekeeping
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -17,19 +17,42 @@ jobs:
         uses: wip/action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies
-        uses: nuxt/actions-yarn@master
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
         with:
-          args: install --frozen-lockfile
-      - name: Verify types
-        uses: nuxt/actions-yarn@master
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - name: Typecheck
+        run: yarn tsc
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
         with:
-          args: tsc
-      - name: Verify tests
-        uses: nuxt/actions-yarn@master
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - name: Tests
+        run: yarn test:ci
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
         with:
-          args: test:ci
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
       - name: Lint
-        uses: nuxt/actions-yarn@master
-        with:
-          args: lint:ci
+        run: yarn lint:ci

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,38 +6,53 @@ on:
       - next
 
 jobs:
-  testAndDeploy:
-    name: Test and deploy
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install dependencies
-        uses: nuxt/actions-yarn@master
+      - uses: actions/setup-node@master
         with:
-          args: install --frozen-lockfile
-      - name: Verify types
-        uses: nuxt/actions-yarn@master
-        with:
-          args: tsc
-      - name: Verify tests
-        uses: nuxt/actions-yarn@master
-        with:
-          args: test:ci
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - name: Typecheck
+        run: yarn tsc
+      - name: Tests
+        run: yarn test:ci
       - name: Lint
-        uses: nuxt/actions-yarn@master
+        run: yarn lint:ci=
+
+  upload-build:
+    name: Upload build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
         with:
-          args: lint:ci
-      - name: Build
-        uses: nuxt/actions-yarn@master
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - name: Build all
+        run: yarn build
+      - name: Upload build
+        run: yarn ts-node src/cli/src/bin.ts upload-build -c demo/build-tracker-cli.config.js
+
+  deploy:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
         with:
-          args: build
+          node-version: 10.x
+      - run: npm install -g yarn
+      - run: yarn install --frozen-lockfile
+      - name: Build docs
+        run: yarn workspace @build-tracker/docs build
       - name: Deploy documentation
         uses: paularmstrong/docusaurus-github-action@master
         env:
           BUILD_DIR: docs/website
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           PROJECT_NAME: build-tracker
-      - name: Upload build
-        uses: nuxt/actions-yarn@master
-        with:
-          args: ts-node src/cli/src/bin.ts upload-build -c demo/build-tracker-cli.config.js


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

The actions, especially for PRs are not explicitly bucketed into jobs.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Bucket them logically so they hopefully run faster and are easy to follow

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
