### PR TITLE
[feature] Add plugin with-mysql

### DIFF
--- a/config/mysql.js
+++ b/config/mysql.js
@@ -1,0 +1,29 @@
+const withMysql = require('@build-tracker/plugin-with-mysql').default;
+const { BudgetLevel, BudgetType } = require('@build-tracker/types');
+
+/**
+ * To run a mysql docker container:
+ * docker run -p 3306:3306 --name bt-mysql -e MYSQL_ROOT_PASSWORD=tacos -e MYSQL_ROOT_HOST=% -e MYSQL_DATABASE=buildtracker -d mysql --default-authentication-plugin=mysql_native_password
+ */
+
+module.exports = withMysql({
+  defaultBranch: 'master',
+  dev: true,
+  artifacts: {
+    groups: [
+      {
+        name: 'Web App',
+        artifactMatch: /^app\/client/,
+        budgets: [{ level: BudgetLevel.ERROR, sizeKey: 'gzip', type: BudgetType.SIZE, maximum: 150000 }]
+      }
+    ]
+  },
+  mysql: {
+    user: 'root',
+    password: 'tacos',
+    database: 'buildtracker',
+    host: '127.0.0.1',
+    port: 3306
+  },
+  url: 'http://localhost:3000'
+});

--- a/docs/docs/guides/development.md
+++ b/docs/docs/guides/development.md
@@ -104,11 +104,11 @@ Here are some things to keep in mind while working in a monorepo:
 
 ### Adding a dependency to a package
 
-To add a third-party dependency to a sub-package in the Build Tracker repository, ensure that it's done from the specific sub-package:
+To add a third-party dependency to a sub-package in the Build Tracker repository, ensure that it's done from the specific sub-package using the `yarn workspace` command:
 
 ```sh
 # To add to the @build-tracker/app package
-$ (cd src/app && yarn add some-third-party-module)
+$ yarn workspace @build-tracker/app add <some-third-party-module>
 ```
 
 ### Don't abstract too early

--- a/docs/docs/plugins/index.md
+++ b/docs/docs/plugins/index.md
@@ -5,5 +5,10 @@ title: Plugins
 
 Plugins are community-developed config composers that make running your server simple. Most plugins remove the need to develop custom database integrations.
 
-- [withPostgres](/docs/plugins/withPostgres)
-- [withMariadb](/docs/plugins/withMariadb)
+- Database Integrations
+  - Postgres
+    - [@build-tracker/plugin-with-postgres](/docs/plugins/withPostgres)
+  - MariaDB
+    - [@build-tracker/plugin-with-mariadb](/docs/plugins/withMariadb)
+  - MySQL
+    - [@build-tracker/plugin-with-mysql](/docs/plugins/withMysql)

--- a/docs/docs/plugins/with-mysql.md
+++ b/docs/docs/plugins/with-mysql.md
@@ -1,0 +1,54 @@
+---
+id: withMysql
+title: MySQL
+---
+
+Connecting your Build Tracker application to a MySQL database is easy with the help of `@build-tracker/plugin-with-mysql`
+
+## Installation
+
+```sh
+yarn add @build-tracker/plugin-with-mysql@latest
+# or
+npm install --save @build-tracker/plugin-with-mysql@latest
+```
+
+## Configuration
+
+Edit your `build-tracker.config.js` file and compose your output configuration:
+
+```js
+const withMysql = require('@build-tracker/plugin-with-mysql');
+
+module.exports = withMysql({
+  mysql: {
+    user: '', // default: process.env.MYSQLUSER
+    host: '', // default: process.env.MYSQLHOST
+    database: '', // default: process.env.MYSQLDATABASE
+    password: '', // default: process.env.MYSQLPASSWORD
+    port: 3306 // default: process.env.MYSQLPORT
+  }
+});
+```
+
+All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
+
+### `host: string = process.env.MYSQLHOST`
+
+Database host.
+
+### `database: string = process.env.MYSQLPASSWORD`
+
+Database name.
+
+### `user: string = process.env.MYSQLUSER`
+
+Database username with read access.
+
+### `password: string = process.env.MYSQLDATABASE`
+
+Password for the given database username.
+
+### `port: number = process.env.MYSQLPORT = 3306`
+
+Database host port.

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -2,7 +2,7 @@
   "docs": {
     "Getting Started": ["installation", "budgets"],
     "Configuration": ["app", "cli"],
-    "Plugins": ["plugins/plugins", "plugins/withPostgres", "plugins/withMariadb"],
+    "Plugins": ["plugins/plugins", "plugins/withPostgres", "plugins/withMariadb", "plugins/withMysql"],
     "Guides": ["guides/guides", "guides/writing-docs", "guides/development"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   ],
   "scripts": {
     "dev": "ts-node src/server/src/index.ts run -c ./config/fixtures.js",
-    "dev:maria": "ts-node src/server/src/index.ts run -c ./config/mariadb.js",
+    "dev:setup": "ts-node src/server/src/index.ts setup",
+    "dev:seed": "ts-node src/server/src/index.ts seed",
+    "dev:mariadb": "ts-node src/server/src/index.ts run -c ./config/mariadb.js",
+    "dev:mysql": "ts-node src/server/src/index.ts run -c ./config/mysql.js",
     "dev:postgres": "ts-node src/server/src/index.ts run -c ./config/postgres.js",
     "docs": "cd docs/website && yarn start",
     "prebuild": "yarnpkg clean",

--- a/plugins/with-mariadb/README.md
+++ b/plugins/with-mariadb/README.md
@@ -1,4 +1,4 @@
-# @build-tracker/plugin-with-postgres
+# @build-tracker/plugin-with-mariadb
 
 A server-configuration plugin for Build Tracker to enable reading build data from a MariaDB database.
 
@@ -20,7 +20,7 @@ Edit your `build-tracker.config.js` file and compose your output configuration:
 const withMariadb = require('@build-tracker/plugin-with-mariadb');
 
 module.exports = withMariadb({
-  pg: {
+  mariadb: {
     user: '', // default: process.env.MARIAUSER
     host: '', // default: process.env.MARIAHOST
     database: '', // default: process.env.MARIADATABASE

--- a/plugins/with-mysql/README.md
+++ b/plugins/with-mysql/README.md
@@ -1,0 +1,53 @@
+# @build-tracker/plugin-with-mysql
+
+A server-configuration plugin for Build Tracker to enable reading build data from a MySQL database.
+
+Connecting your Build Tracker application to a MySQL database is easy with the help of `@build-tracker/plugin-with-mysql`
+
+## Installation
+
+```sh
+yarn add @build-tracker/plugin-with-mysql@latest
+# or
+npm install --save @build-tracker/plugin-with-mysql@latest
+```
+
+## Configuration
+
+Edit your `build-tracker.config.js` file and compose your output configuration:
+
+```js
+const withMysql = require('@build-tracker/plugin-with-mysql');
+
+module.exports = withMysql({
+  mysql: {
+    user: '', // default: process.env.MYSQLUSER
+    host: '', // default: process.env.MYSQLHOST
+    database: '', // default: process.env.MYSQLDATABASE
+    password: '', // default: process.env.MYSQLPASSWORD
+    port: 3306 // default: process.env.MYSQLPORT
+  }
+});
+```
+
+All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
+
+### `host: string = process.env.MYSQLHOST`
+
+Database host.
+
+### `database: string = process.env.MYSQLPASSWORD`
+
+Database name.
+
+### `user: string = process.env.MYSQLUSER`
+
+Database username with read access.
+
+### `password: string = process.env.MYSQLDATABASE`
+
+Password for the given database username.
+
+### `port: number = process.env.MYSQLPORT = 3306`
+
+Database host port.

--- a/plugins/with-mysql/jest.config.js
+++ b/plugins/with-mysql/jest.config.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+module.exports = {
+  displayName: 'with-mysql',
+  testEnvironment: 'node',
+  resetMocks: true,
+  rootDir: './',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  }
+};

--- a/plugins/with-mysql/package.json
+++ b/plugins/with-mysql/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@build-tracker/plugin-with-mysql",
+  "version": "1.0.0-alpha.3",
+  "description": "Build Tracker server plugin for MariaDB",
+  "author": "Paul Armstrong <paul@spaceyak.com>",
+  "repository": "git@github.com:paularmstrong/build-tracker.git",
+  "license": "MIT",
+  "main": "dist",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "tsc": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@build-tracker/api-errors": "^1.0.0-alpha.3",
+    "@build-tracker/build": "^1.0.0-alpha.3",
+    "dotenv": "^7.0.0",
+    "mysql": "^2.17.1"
+  },
+  "devDependencies": {
+    "@build-tracker/types": "^1.0.0-alpha.3",
+    "@types/dotenv": "^6.1.0",
+    "@types/mysql": "^2.15.7"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "fc5443c746fb03f29f7c64815cc67e7b7a0b355d"
+}

--- a/plugins/with-mysql/src/__tests__/index.test.ts
+++ b/plugins/with-mysql/src/__tests__/index.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import withMysql from '../';
+
+const url = 'https://build-tracker.local';
+
+jest.mock('mysql');
+
+describe('withMysql', () => {
+  test('preserves user-set config', () => {
+    expect(withMysql({ mysql: {}, port: 1234, url })).toMatchObject({ port: 1234 });
+  });
+
+  test('adds setup', () => {
+    expect(withMysql({ mysql: {}, url })).toHaveProperty('setup');
+  });
+
+  test('adds queries', () => {
+    expect(withMysql({ mysql: {}, url })).toMatchObject({
+      queries: {
+        build: {
+          byRevision: expect.any(Function),
+          insert: expect.any(Function)
+        },
+        builds: {
+          byRevisions: expect.any(Function),
+          byRevisionRange: expect.any(Function),
+          byTimeRange: expect.any(Function)
+        }
+      }
+    });
+  });
+});

--- a/plugins/with-mysql/src/__tests__/setup.test.ts
+++ b/plugins/with-mysql/src/__tests__/setup.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Mysql from 'mysql';
+import setup from '../setup';
+
+describe('withMysql setup', () => {
+  let query, release, setupFn;
+  beforeEach(() => {
+    query = jest.fn((_query, cb) => {
+      cb(null);
+    });
+    release = jest.fn();
+    // @ts-ignore
+    jest.spyOn(Mysql, 'createPool').mockImplementation(() => ({
+      getConnection: cb => {
+        // @ts-ignore
+        cb(null, { query, release });
+      }
+    }));
+
+    setupFn = setup(Mysql.createPool({}));
+  });
+
+  test('creates the table if not exists', async () => {
+    await expect(setupFn()).resolves.toBe(true);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringMatching('CREATE TABLE IF NOT EXISTS builds'),
+      expect.any(Function)
+    );
+  });
+
+  test('creates a multi-index', async () => {
+    await expect(setupFn()).resolves.toBe(true);
+    expect(query).toHaveBeenCalledWith(
+      'ALTER TABLE builds ADD INDEX (revision, parentRevision, branch)',
+      expect.any(Function)
+    );
+  });
+
+  test('creates an index on timestamp', async () => {
+    await expect(setupFn()).resolves.toBe(true);
+    expect(query).toHaveBeenCalledWith('ALTER TABLE builds ADD INDEX (timestamp)', expect.any(Function));
+  });
+
+  test('releases the client on complete', async () => {
+    await expect(setupFn()).resolves.toBe(true);
+    expect(release).toHaveBeenCalled();
+  });
+
+  test('releases the client on error', async () => {
+    const error = new Error('tacos');
+    query.mockImplementationOnce((_query, cb) => {
+      cb(error);
+    });
+    await expect(setupFn()).rejects.toThrow(error);
+    expect(release).toHaveBeenCalled();
+  });
+});

--- a/plugins/with-mysql/src/index.ts
+++ b/plugins/with-mysql/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { config } from 'dotenv';
+import Queries from './queries';
+import { ServerConfig } from '@build-tracker/server/src/server';
+import setup from './setup';
+import { createPool, PoolConfig } from 'mysql';
+
+config();
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export default function withMysql(config: Omit<ServerConfig, 'queries'> & { mysql: PoolConfig }): ServerConfig {
+  const { mysql: mysqlConfig } = config;
+  const database = mysqlConfig.database || process.env.MYSQLDATABASE || 'buildtracker';
+
+  const pool = createPool({
+    user: process.env.MYSQLUSER,
+    host: process.env.MYSQLHOST,
+    password: process.env.MYSQLPASSWORD,
+    port: process.env.MYSQLPORT ? parseInt(process.env.MYSQLPORT, 10) : 3306,
+    ...mysqlConfig,
+    database
+  });
+
+  const queries = new Queries(pool);
+
+  return {
+    ...config,
+    setup: setup(pool),
+    queries: {
+      build: {
+        byRevision: queries.getByRevision,
+        insert: queries.insert
+      },
+      builds: {
+        byRevisions: queries.getByRevisions,
+        byRevisionRange: queries.getByRevisionRange,
+        byTimeRange: queries.getByTimeRange,
+        recent: queries.getRecent
+      }
+    }
+  };
+}

--- a/plugins/with-mysql/src/queries.ts
+++ b/plugins/with-mysql/src/queries.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { Build as BuildStruct } from '@build-tracker/server/src/types';
+import { Pool } from 'mysql';
+import { NotFoundError, UnimplementedError } from '@build-tracker/api-errors';
+
+export default class Queries {
+  private _pool: Pool;
+
+  public constructor(pool: Pool) {
+    this._pool = pool;
+  }
+
+  public getByRevision = (revision: string): Promise<BuildStruct> => {
+    return new Promise((resolve, reject) => {
+      this._pool.query(
+        'SELECT meta, artifacts FROM builds WHERE revision = ?',
+        [revision],
+        (err, results): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          if (results.length !== 1) {
+            reject(new NotFoundError());
+            return;
+          }
+
+          resolve(this._formatRow(results[0]));
+        }
+      );
+    });
+  };
+
+  public insert = ({ meta, artifacts }: BuildStruct): Promise<string> => {
+    const build = new Build(meta, artifacts);
+    return new Promise((resolve, reject) => {
+      this._pool.query(
+        'INSERT INTO builds (branch, revision, timestamp, parentRevision, meta, artifacts) VALUES (?, ?, ?, ?, ?, ?)',
+        [
+          build.getMetaValue('branch'),
+          build.getMetaValue('revision'),
+          build.meta.timestamp,
+          build.getMetaValue('parentRevision'),
+          JSON.stringify(build.meta),
+          JSON.stringify(build.artifacts)
+        ],
+        (err, results): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve(results.insertId);
+        }
+      );
+    });
+  };
+
+  public getByRevisions = (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+    return new Promise((resolve, reject) => {
+      this._pool.query(
+        'SELECT meta, artifacts FROM builds WHERE revision in ?',
+        [revisions],
+        (err, results): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          if (!results.length) {
+            reject(new NotFoundError());
+            return;
+          }
+
+          resolve(results.map(this._formatRow));
+        }
+      );
+    });
+  };
+
+  public getByRevisionRange = (startRevision: string, endRevision: string): Promise<Array<BuildStruct>> => {
+    return new Promise((_resolve, reject) => {
+      reject(new UnimplementedError(`revision range ${startRevision} - ${endRevision}`));
+    });
+  };
+
+  public getByTimeRange = (
+    startTimestamp: number,
+    endTimestamp: number,
+    branch: string
+  ): Promise<Array<BuildStruct>> => {
+    return new Promise((resolve, reject) => {
+      this._pool.query(
+        'SELECT meta, artifacts FROM builds WHERE timestamp >= ? AND timestamp <= ? AND branch = ? ORDER BY timestamp',
+        [startTimestamp, endTimestamp, branch],
+        (err, results): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          if (!results.length) {
+            reject(new NotFoundError());
+            return;
+          }
+
+          resolve(results.map(this._formatRow));
+        }
+      );
+    });
+  };
+
+  public getRecent = (limit: number = 20, branch: string): Promise<Array<BuildStruct>> => {
+    return new Promise((resolve, reject) => {
+      this._pool.query(
+        'SELECT meta, artifacts FROM builds WHERE branch = ? ORDER BY timestamp DESC LIMIT ?',
+        [branch, limit],
+        (err, results): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          if (!results.length) {
+            reject(new NotFoundError());
+            return;
+          }
+
+          resolve(results.map(this._formatRow).sort((a, b) => a.meta.timestamp - b.meta.timestamp));
+        }
+      );
+    });
+  };
+
+  private _formatRow(row: { meta: Buffer; artifacts: Buffer }): BuildStruct {
+    return { meta: JSON.parse(row.meta.toString()), artifacts: JSON.parse(row.artifacts.toString()) };
+  }
+}

--- a/plugins/with-mysql/src/setup.ts
+++ b/plugins/with-mysql/src/setup.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Pool } from 'mysql';
+
+export default function setup(pool: Pool): () => Promise<boolean> {
+  const setup = (): Promise<boolean> => {
+    return new Promise(resolve => {
+      pool.getConnection((err, client) => {
+        if (err) {
+          client.release();
+          throw err;
+        }
+        client.query(
+          `
+CREATE TABLE IF NOT EXISTS builds(
+  revision VARCHAR(64) PRIMARY KEY NOT NULL,
+  branch VARCHAR(64) NOT NULL,
+  parentRevision VARCHAR(64),
+  timestamp INT NOT NULL,
+  meta VARCHAR(1024),
+  artifacts BLOB,
+  CHECK (meta IS NULL OR JSON_VALID(meta))
+)`,
+          err => {
+            if (err) {
+              client.release();
+              throw err;
+            }
+            client.query('ALTER TABLE builds ADD INDEX (revision, parentRevision, branch)', err => {
+              if (err) {
+                client.release();
+                throw err;
+              }
+              client.query('ALTER TABLE builds ADD INDEX (timestamp)', err => {
+                if (err) {
+                  client.release();
+                  throw err;
+                }
+                client.release();
+                resolve(true);
+              });
+            });
+          }
+        );
+      });
+    });
+  };
+
+  return setup;
+}
+
+module.exports = setup;

--- a/plugins/with-mysql/tsconfig.json
+++ b/plugins/with-mysql/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mysql@^2.15.7":
+  version "2.15.7"
+  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.7.tgz#7b803d0d8f418ee7edbdaceb1e7a43b322b346dc"
+  integrity sha512-S7cpDl+heeTe2zd7LGeAodEsx9AnkzW1vHJ9kKwr9ype1KohW01jaUmCYhpafrQvnxzcUJAfeYdDr3fET8ufPw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^12.0.0":
   version "12.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
@@ -2875,6 +2882,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bignumber.js@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
 bin-build@^3.0.0:
   version "3.0.0"
@@ -9223,6 +9235,16 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mysql@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.17.1.tgz#62bba4a039a9b2f73638cd1652ce50fc6f682899"
+  integrity sha512-7vMqHQ673SAk5C8fOzTG2LpPcf3bNt0oL3sFpxPEEFp1mdlDcrLK0On7z8ZYKaaHrHwNcQ/MTUz7/oobZ2OyyA==
+  dependencies:
+    bignumber.js "7.2.1"
+    readable-stream "2.3.6"
+    safe-buffer "5.1.2"
+    sqlstring "2.3.1"
+
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -11331,7 +11353,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2.3.6, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -12361,6 +12383,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sqlstring@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
+  integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=
 
 squeak@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

While the MariaDB plugin _may_ work with MySQL databases, it's potential that it won't always work. Probably better to create an official plugin now so it's easier to maintain later.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Mostly copypasta from `with-mariadb`, but uses the `mysql` package from NPM, which does not use promises, so I had to get into callbacks.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
