### PR TITLE
[app] Add routing, enable linking & direct build queries

### DIFF
--- a/config/fixtures.js
+++ b/config/fixtures.js
@@ -42,8 +42,8 @@ module.exports = {
       }
     },
     builds: {
-      byRevisions: async (...revisions) => {
-        return Promise.resolve(Array.from(builds.values()).filter(build => revisions.includes(build.meta.revision)));
+      byRevisions: async revisions => {
+        return Promise.resolve(revisions.map(revision => builds.get(revision)).filter(Boolean));
       },
       byRevisionRange: async () => {
         throw new UnimplementedError();

--- a/docs/docs/app.md
+++ b/docs/docs/app.md
@@ -192,7 +192,7 @@ interface Queries {
     insert: (build: Build) => Promise<string>;
   };
   builds: {
-    byRevisions: (...revisions: Array<string>) => Promise<Array<Build>>;
+    byRevisions: (revisions: Array<string>) => Promise<Array<Build>>;
     byRevisionRange: (startRevision: string, endRevision: string) => Promise<Array<Build>>;
     byTimeRange: (startTimestamp: number, endTimestamp: number, branch: string) => Promise<Array<Build>>;
     recent: (limit: number, branch: string) => Promise<Array<Build>>;

--- a/docs/docs/guides/guides.md
+++ b/docs/docs/guides/guides.md
@@ -4,7 +4,6 @@ title: Guides
 sidebar_label: Guides
 ---
 
-Thank you for your interest in helping out with Build Tracker! This is a project done with joy and care, out of our free time. Before getting started, please familiarize yourself with the [Contributor Covenant Code of Conduct](https://github.com/paularmstrong/build-tracker/blob/next/CODE_OF_CONDUCT.md).
-
+- [Continuous Integration](ci)
 - [Writing documentation](writing-docs)
 - [Development](development)

--- a/docs/website/sidebars.json
+++ b/docs/website/sidebars.json
@@ -3,6 +3,6 @@
     "Getting Started": ["installation", "budgets"],
     "Configuration": ["app", "cli"],
     "Plugins": ["plugins/plugins", "plugins/withPostgres", "plugins/withMariadb", "plugins/withMysql"],
-    "Guides": ["guides/guides", "guides/writing-docs", "guides/development"]
+    "Guides": ["guides/guides", "guides/ci", "guides/writing-docs", "guides/development"]
   }
 }

--- a/plugins/with-mariadb/src/__tests__/queries.test.ts
+++ b/plugins/with-mariadb/src/__tests__/queries.test.ts
@@ -68,7 +68,7 @@ describe('withMariadb queries', () => {
   describe('getByRevisions', () => {
     test('selects meta and artifacts', async () => {
       query.mockReturnValue(Promise.resolve([row1, row2]));
-      await expect(queries.getByRevisions('12345', 'abcde')).resolves.toEqual([row1Result, row2Result]);
+      await expect(queries.getByRevisions(['12345', 'abcde'])).resolves.toEqual([row1Result, row2Result]);
       expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in ?', [
         ['12345', 'abcde']
       ]);
@@ -76,7 +76,7 @@ describe('withMariadb queries', () => {
 
     test('throws with no results', async () => {
       query.mockReturnValue(Promise.resolve([]));
-      await expect(queries.getByRevisions('12345', 'abcde')).rejects.toThrow(NotFoundError);
+      await expect(queries.getByRevisions(['12345', 'abcde'])).rejects.toThrow(NotFoundError);
     });
   });
 

--- a/plugins/with-mariadb/src/queries.ts
+++ b/plugins/with-mariadb/src/queries.ts
@@ -39,7 +39,7 @@ export default class Queries {
     return Promise.resolve(build.getMetaValue('revision'));
   };
 
-  public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+  public getByRevisions = async (revisions: Array<string>): Promise<Array<BuildStruct>> => {
     const rows = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in ?', [revisions]);
     if (!rows.length) {
       throw new NotFoundError();

--- a/plugins/with-mysql/src/__tests__/queries.test.ts
+++ b/plugins/with-mysql/src/__tests__/queries.test.ts
@@ -80,7 +80,7 @@ describe('withMysql queries', () => {
       query.mockImplementation((_query, _args, cb) => {
         cb(null, [row1, row2]);
       });
-      await expect(queries.getByRevisions('12345', 'abcde')).resolves.toEqual([row1Result, row2Result]);
+      await expect(queries.getByRevisions(['12345', 'abcde'])).resolves.toEqual([row1Result, row2Result]);
       expect(query).toHaveBeenCalledWith(
         'SELECT meta, artifacts FROM builds WHERE revision in ?',
         [['12345', 'abcde']],
@@ -89,7 +89,7 @@ describe('withMysql queries', () => {
     });
 
     test('throws with no results', async () => {
-      await expect(queries.getByRevisions('12345', 'abcde')).rejects.toThrow(NotFoundError);
+      await expect(queries.getByRevisions(['12345', 'abcde'])).rejects.toThrow(NotFoundError);
     });
   });
 

--- a/plugins/with-mysql/src/queries.ts
+++ b/plugins/with-mysql/src/queries.ts
@@ -59,7 +59,7 @@ export default class Queries {
     });
   };
 
-  public getByRevisions = (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+  public getByRevisions = (revisions: Array<string>): Promise<Array<BuildStruct>> => {
     return new Promise((resolve, reject) => {
       this._pool.query(
         'SELECT meta, artifacts FROM builds WHERE revision in ?',

--- a/plugins/with-postgres/src/__tests__/queries.test.ts
+++ b/plugins/with-postgres/src/__tests__/queries.test.ts
@@ -78,7 +78,7 @@ describe('withPostgres', () => {
       const row2 = { meta: { branch: 'master', revision: 'abcde' }, artifacts: [] };
       query.mockReturnValue(Promise.resolve({ rowCount: 2, rows: [row1, row2] }));
       const queries = new Queries(new Pool());
-      return queries.getByRevisions('12345', 'abcde').then(res => {
+      return queries.getByRevisions(['12345', 'abcde']).then(res => {
         expect(query).toHaveBeenCalledWith('SELECT meta, artifacts FROM builds WHERE revision in $1', [
           ['12345', 'abcde']
         ]);
@@ -89,7 +89,7 @@ describe('withPostgres', () => {
     test('throws with no results', () => {
       query.mockReturnValue(Promise.resolve({ rowCount: 0 }));
       const queries = new Queries(new Pool());
-      return queries.getByRevisions('12345', 'abcde').catch(err => {
+      return queries.getByRevisions(['12345', 'abcde']).catch(err => {
         expect(err).toBeInstanceOf(NotFoundError);
       });
     });

--- a/plugins/with-postgres/src/queries.ts
+++ b/plugins/with-postgres/src/queries.ts
@@ -43,7 +43,7 @@ export default class Queries {
     return Promise.resolve(build.getMetaValue('revision'));
   };
 
-  public getByRevisions = async (...revisions: Array<string>): Promise<Array<BuildStruct>> => {
+  public getByRevisions = async (revisions: Array<string>): Promise<Array<BuildStruct>> => {
     const res = await this._pool.query('SELECT meta, artifacts FROM builds WHERE revision in $1', [revisions]);
     if (res.rowCount === 0) {
       throw new NotFoundError();

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.9.0",
     "react-native-web": "^0.11.7",
     "react-redux": "^7.1.1",
+    "react-router": "^5.0.1",
     "redux": "^4.0.4",
     "tosource": "^1.0.0",
     "uuid": "^3.3.2"
@@ -51,6 +52,7 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-native": "^0.60.0",
     "@types/react-redux": "^7.1.2",
+    "@types/react-router": "^5.0.3",
     "chalk": "^2.4.2",
     "file-loader": "^4.2.0",
     "mkdirp": "^0.5.1",

--- a/src/app/src/client/Routes.tsx
+++ b/src/app/src/client/Routes.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Builds from './routes/Builds';
+import Dates from './routes/Dates';
+import Latest from './routes/Latest';
+import React, { FunctionComponent } from 'react';
+import { Route, Switch } from 'react-router';
+
+const Routes: FunctionComponent<{}> = (): React.ReactElement => {
+  return (
+    <Switch>
+      <Route exact path="/" component={Latest} />
+      <Route exact path="/builds/dates/:startTimestamp..:endTimestamp" component={Dates} />
+      <Route exact path="/builds/limit/:limit" component={Latest} />
+      <Route exact path="/builds/:revisions+" component={Builds} />
+    </Switch>
+  );
+};
+
+export default Routes;

--- a/src/app/src/client/history.ts
+++ b/src/app/src/client/history.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
+import { createBrowserHistory, createMemoryHistory } from 'history';
+
+export default (canUseDOM ? createBrowserHistory() : createMemoryHistory());

--- a/src/app/src/client/index.tsx
+++ b/src/app/src/client/index.tsx
@@ -2,11 +2,14 @@
  * Copyright (c) 2019 Paul Armstrong
  */
 import { AppRegistry } from 'react-native';
+import history from './history';
 import Main from '../screens/Main';
 import makeStore from '../store';
 import { Provider } from 'react-redux';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Router } from 'react-router';
+import Routes from './Routes';
 
 // @ts-ignore
 const initialProps = window.__PROPS__ || {};
@@ -14,7 +17,10 @@ const store = makeStore(initialProps);
 
 const App = (): React.ReactElement => (
   <Provider store={store}>
-    <Main />
+    <Router history={history}>
+      <Routes />
+      <Main />
+    </Router>
   </Provider>
 );
 

--- a/src/app/src/client/index.tsx
+++ b/src/app/src/client/index.tsx
@@ -13,7 +13,17 @@ import Routes from './Routes';
 
 // @ts-ignore
 const initialProps = window.__PROPS__ || {};
-const store = makeStore(initialProps);
+const params = new URLSearchParams(window.location.search.replace(/^\?/, ''));
+const objParams = {
+  activeArtifacts: params
+    .getAll('activeArtifacts')
+    .reduce((memo, artifactName) => ({ ...memo, [artifactName]: true }), {}),
+  sizeKey: params.get('sizeKey'),
+  disabledArtifactsVisible: params.get('disabledArtifactsVisible') === 'false' ? false : true,
+  comparedRevisions: params.getAll('comparedRevisions') || []
+};
+
+const store = makeStore({ ...initialProps, ...objParams });
 
 const App = (): React.ReactElement => (
   <Provider store={store}>

--- a/src/app/src/client/routes/Builds.tsx
+++ b/src/app/src/client/routes/Builds.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { fetch } from 'cross-fetch';
+import { RouteComponentProps } from 'react-router';
+import { FetchState, State } from '../../store/types';
+import React, { FunctionComponent } from 'react';
+import { setBuilds, setFetchState } from '../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
+
+const Builds: FunctionComponent<RouteComponentProps<{ revisions: string }>> = (props): React.ReactElement => {
+  const { revisions } = props.match.params;
+  const url = useSelector((state: State) => state.url);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    dispatch(setFetchState(FetchState.FETCHING));
+    fetch(`${url}/api/builds/list/${revisions}`)
+      .then(response => response.json())
+      .then(builds => {
+        if (!Array.isArray(builds)) {
+          throw new Error('Bad response');
+        }
+        dispatch(setBuilds(builds.map(buildStruct => new Build(buildStruct.meta, buildStruct.artifacts))));
+        dispatch(setFetchState(FetchState.FETCHED));
+      })
+      .catch(() => {
+        dispatch(setFetchState(FetchState.ERROR));
+      });
+  }, [dispatch, revisions, url]);
+  return null;
+};
+
+export default Builds;

--- a/src/app/src/client/routes/Dates.tsx
+++ b/src/app/src/client/routes/Dates.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { fetch } from 'cross-fetch';
+import { RouteComponentProps } from 'react-router';
+import { FetchState, State } from '../../store/types';
+import React, { FunctionComponent } from 'react';
+import { setBuilds, setFetchState } from '../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
+
+const Dates: FunctionComponent<RouteComponentProps<{ endTimestamp: string; startTimestamp: string }>> = (
+  props
+): React.ReactElement => {
+  const { startTimestamp, endTimestamp } = props.match.params;
+  const url = useSelector((state: State) => state.url);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    dispatch(setFetchState(FetchState.FETCHING));
+    fetch(`${url}/api/builds/time/${startTimestamp}...${endTimestamp}`)
+      .then(response => response.json())
+      .then(builds => {
+        if (!Array.isArray(builds)) {
+          throw new Error('Bad response');
+        }
+        dispatch(setBuilds(builds.map(buildStruct => new Build(buildStruct.meta, buildStruct.artifacts))));
+        dispatch(setFetchState(FetchState.FETCHED));
+      })
+      .catch(() => {
+        dispatch(setFetchState(FetchState.ERROR));
+      });
+  }, [dispatch, endTimestamp, startTimestamp, url]);
+  return null;
+};
+
+export default Dates;

--- a/src/app/src/client/routes/Latest.tsx
+++ b/src/app/src/client/routes/Latest.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import { fetch } from 'cross-fetch';
+import { RouteComponentProps } from 'react-router';
+import { FetchState, State } from '../../store/types';
+import React, { FunctionComponent } from 'react';
+import { setBuilds, setFetchState } from '../../store/actions';
+import { useDispatch, useSelector } from 'react-redux';
+
+const DEFAULT_LIMIT = '30';
+
+const Latest: FunctionComponent<RouteComponentProps<{ limit?: string }>> = (props): React.ReactElement => {
+  const { limit = DEFAULT_LIMIT } = props.match.params;
+  const url = useSelector((state: State) => state.url);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    dispatch(setFetchState(FetchState.FETCHING));
+    fetch(`${url}/api/builds/${limit}`)
+      .then(response => response.json())
+      .then(builds => {
+        if (!Array.isArray(builds)) {
+          throw new Error('Bad response');
+        }
+        dispatch(setBuilds(builds.map(buildStruct => new Build(buildStruct.meta, buildStruct.artifacts))));
+        dispatch(setFetchState(FetchState.FETCHED));
+      })
+      .catch(() => {
+        dispatch(setFetchState(FetchState.ERROR));
+      });
+  }, [dispatch, limit, url]);
+  return null;
+};
+
+export default Latest;

--- a/src/app/src/client/routes/__tests__/Builds.test.tsx
+++ b/src/app/src/client/routes/__tests__/Builds.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Actions from '../../../store/actions';
+import * as CrossFetch from 'cross-fetch';
+import Build from '@build-tracker/build';
+import buildA from '@build-tracker/fixtures/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
+import buildB from '@build-tracker/fixtures/builds/01141f29743fb2bdd7e176cf919fc964025cea5a.json';
+import buildC from '@build-tracker/fixtures/builds/243024909db66ac3c3e48d2ffe4015f049609834.json';
+import Builds from '../Builds';
+import { FetchState } from '../../../store/types';
+import mockStore from '../../../store/mock';
+import { Provider } from 'react-redux';
+import React from 'react';
+import { flushMicrotasksQueue, render } from 'react-native-testing-library';
+
+const url = 'https://build-tracker.local';
+
+jest.mock('cross-fetch', () => {
+  return {
+    fetch: jest.fn()
+  };
+});
+
+const REVISIONS_QUERY =
+  '22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04/01141f29743fb2bdd7e176cf919fc964025cea5a/243024909db66ac3c3e48d2ffe4015f049609834';
+
+const renderLimit = async (revisions: string = REVISIONS_QUERY): Promise<void> => {
+  render(
+    <Provider
+      store={mockStore({
+        builds: [],
+        comparedRevisions: [],
+        snacks: [],
+        url
+      })}
+    >
+      <Builds
+        // @ts-ignore
+        match={{ params: { revisions } }}
+      />
+    </Provider>
+  );
+  await flushMicrotasksQueue();
+};
+
+describe('Builds', () => {
+  let fetchSpy, setFetchStateSpy, setBuildsSpy;
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(CrossFetch, 'fetch').mockImplementation(() =>
+      // @ts-ignore
+      Promise.resolve({
+        json: () => Promise.resolve([buildA, buildB, buildC])
+      })
+    );
+    setFetchStateSpy = jest.spyOn(Actions, 'setFetchState');
+    setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
+  });
+
+  test('fetches builds for the given query', async () => {
+    await renderLimit();
+
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHING);
+    expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/list/${REVISIONS_QUERY}`);
+    expect(setBuildsSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.any(Build), expect.any(Build), expect.any(Build)])
+    );
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHED);
+  });
+
+  test('sets fetch state error if response fails', async () => {
+    fetchSpy.mockImplementation(() => Promise.reject(new Error('some error')));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+
+  test('sets fetch state error if response is not an array', async () => {
+    fetchSpy.mockImplementation(() => Promise.resolve({ json: () => 'tacos' }));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+});

--- a/src/app/src/client/routes/__tests__/Dates.test.tsx
+++ b/src/app/src/client/routes/__tests__/Dates.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Actions from '../../../store/actions';
+import * as CrossFetch from 'cross-fetch';
+import Build from '@build-tracker/build';
+import buildA from '@build-tracker/fixtures/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
+import buildB from '@build-tracker/fixtures/builds/01141f29743fb2bdd7e176cf919fc964025cea5a.json';
+import buildC from '@build-tracker/fixtures/builds/243024909db66ac3c3e48d2ffe4015f049609834.json';
+import Dates from '../Dates';
+import { FetchState } from '../../../store/types';
+import mockStore from '../../../store/mock';
+import { Provider } from 'react-redux';
+import React from 'react';
+import { flushMicrotasksQueue, render } from 'react-native-testing-library';
+
+const url = 'https://build-tracker.local';
+
+jest.mock('cross-fetch', () => {
+  return {
+    fetch: jest.fn()
+  };
+});
+
+const renderLimit = async (startTimestamp: string = '100', endTimestamp: string = '200'): Promise<void> => {
+  render(
+    <Provider
+      store={mockStore({
+        builds: [],
+        comparedRevisions: [],
+        snacks: [],
+        url
+      })}
+    >
+      <Dates
+        // @ts-ignore
+        match={{ params: { startTimestamp, endTimestamp } }}
+      />
+    </Provider>
+  );
+  await flushMicrotasksQueue();
+};
+
+describe('Dates', () => {
+  let fetchSpy, setFetchStateSpy, setBuildsSpy;
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(CrossFetch, 'fetch').mockImplementation(() =>
+      // @ts-ignore
+      Promise.resolve({
+        json: () => Promise.resolve([buildA, buildB, buildC])
+      })
+    );
+    setFetchStateSpy = jest.spyOn(Actions, 'setFetchState');
+    setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
+  });
+
+  test('fetches builds for the range', async () => {
+    await renderLimit();
+
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHING);
+    expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/time/100...200`);
+    expect(setBuildsSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.any(Build), expect.any(Build), expect.any(Build)])
+    );
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHED);
+  });
+
+  test('fetches builds with a custom limit', async () => {
+    await renderLimit('300', '400');
+    expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/time/300...400`);
+  });
+
+  test('sets fetch state error if response fails', async () => {
+    fetchSpy.mockImplementation(() => Promise.reject(new Error('some error')));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+
+  test('sets fetch state error if response is not an array', async () => {
+    fetchSpy.mockImplementation(() => Promise.resolve({ json: (): string => 'tacos' }));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+});

--- a/src/app/src/client/routes/__tests__/Latest.test.tsx
+++ b/src/app/src/client/routes/__tests__/Latest.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Actions from '../../../store/actions';
+import * as CrossFetch from 'cross-fetch';
+import Build from '@build-tracker/build';
+import buildA from '@build-tracker/fixtures/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
+import buildB from '@build-tracker/fixtures/builds/01141f29743fb2bdd7e176cf919fc964025cea5a.json';
+import buildC from '@build-tracker/fixtures/builds/243024909db66ac3c3e48d2ffe4015f049609834.json';
+import { FetchState } from '../../../store/types';
+import Latest from '../Latest';
+import mockStore from '../../../store/mock';
+import { Provider } from 'react-redux';
+import React from 'react';
+import { flushMicrotasksQueue, render } from 'react-native-testing-library';
+
+const url = 'https://build-tracker.local';
+
+jest.mock('cross-fetch', () => {
+  return {
+    fetch: jest.fn()
+  };
+});
+
+const renderLimit = async (limit: number = undefined): Promise<void> => {
+  render(
+    <Provider
+      store={mockStore({
+        builds: [],
+        comparedRevisions: [],
+        snacks: [],
+        url
+      })}
+    >
+      <Latest
+        // @ts-ignore
+        match={{ params: { limit } }}
+      />
+    </Provider>
+  );
+  await flushMicrotasksQueue();
+};
+
+describe('Latest', () => {
+  let fetchSpy, setFetchStateSpy, setBuildsSpy;
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(CrossFetch, 'fetch').mockImplementation(() =>
+      // @ts-ignore
+      Promise.resolve({
+        json: () => Promise.resolve([buildA, buildB, buildC])
+      })
+    );
+    setFetchStateSpy = jest.spyOn(Actions, 'setFetchState');
+    setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
+  });
+
+  test('fetches builds with a default limit', async () => {
+    await renderLimit();
+
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHING);
+    expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/30`);
+    expect(setBuildsSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.any(Build), expect.any(Build), expect.any(Build)])
+    );
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.FETCHED);
+  });
+
+  test('fetches builds with a custom limit', async () => {
+    await renderLimit(10);
+    expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/10`);
+  });
+
+  test('sets fetch state error if response fails', async () => {
+    fetchSpy.mockImplementation(() => Promise.reject(new Error('some error')));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+
+  test('sets fetch state error if response is not an array', async () => {
+    fetchSpy.mockImplementation(() => Promise.resolve({ json: (): string => 'tacos' }));
+    await renderLimit();
+    expect(setBuildsSpy).not.toHaveBeenCalled();
+    expect(setFetchStateSpy).toHaveBeenCalledWith(FetchState.ERROR);
+  });
+});

--- a/src/app/src/components/Divider.tsx
+++ b/src/app/src/components/Divider.tsx
@@ -3,23 +3,23 @@
  */
 import * as Theme from '../theme';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 interface Props {
   color?: string;
+  style?: StyleProp<ViewStyle>;
 }
 
 const Divider = (props: Props): React.ReactElement => {
-  const { color } = props;
-  return <View style={[styles.root, color && { backgroundColor: color }]} />;
+  const { color, style } = props;
+  return <View style={[styles.root, color && { backgroundColor: color }, style]} />;
 };
 
 const styles = StyleSheet.create({
   root: {
     height: StyleSheet.hairlineWidth,
     overflow: 'hidden',
-    backgroundColor: Theme.Color.Gray20,
-    marginBottom: Theme.Spacing.Normal
+    backgroundColor: Theme.Color.Gray20
   }
 });
 

--- a/src/app/src/icons/Link.tsx
+++ b/src/app/src/icons/Link.tsx
@@ -1,0 +1,32 @@
+/**
+ * Material design redistributed from https://github.com/google/material-design-icons
+ *
+ * SVG contents redistributed under Apache License 2.0:
+ * https://github.com/google/material-design-icons/blob/master/LICENSE
+ * Copyright 2015 Google, Inc. All Rights Reserved.
+ */
+import React from 'react';
+import styles from './styles';
+import { createElement, StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+interface Props {
+  style?: StyleProp<ViewStyle & TextStyle>;
+}
+
+const Link = (props: Props): React.ReactElement<Props> =>
+  createElement(
+    'svg',
+    {
+      ...props,
+      style: [styles.root, props.style],
+      viewBox: '0 0 24 24'
+    },
+    <g>
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
+    </g>
+  );
+
+Link.metadata = { height: 24, width: 24 };
+
+export default Link;

--- a/src/app/src/screens/Main.tsx
+++ b/src/app/src/screens/Main.tsx
@@ -3,71 +3,22 @@
  */
 import * as Theme from '../theme';
 import AppBarView from '../views/AppBar';
-import Build from '@build-tracker/build';
 import { Handles as DrawerHandles } from '../components/Drawer';
 import DrawerView from '../views/Drawer';
-import { fetch } from 'cross-fetch';
 import Graph from '../views/Graph';
 import React from 'react';
-import { setBuilds } from '../store/actions';
 import Snacks from '../views/Snacks';
-import { State } from '../store/types';
+import { useSelector } from 'react-redux';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { FetchState, State } from '../store/types';
 
 const Comparison = React.lazy(() => import(/* webpackChunkName: "Comparison" */ '../views/Comparison'));
-
-const dateToSeconds = (date: Date): number => Math.round(date.valueOf() / 1000);
-
-enum FetchState {
-  NONE,
-  FETCHING,
-  FETCHED,
-  ERROR
-}
 
 const Main = (): React.ReactElement => {
   const drawerRef = React.useRef<DrawerHandles>(null);
 
-  const buildsCount = useSelector((state: State) => state.builds.length);
-  const requestedBuildsCount = useSelector((state: State) => state.buildCount);
-  const dateRange = useSelector((state: State) => state.dateRange);
   const showComparisonTable = useSelector((state: State) => !!state.comparedRevisions.length);
-  const url = useSelector((state: State) => state.url);
-  const [fetchState, setFetchState] = React.useState<FetchState>(FetchState.NONE);
-  const dispatch = useDispatch();
-
-  React.useEffect(() => {
-    if (dateRange) {
-      setFetchState(FetchState.FETCHING);
-      fetch(`${url}/api/builds/time/${dateToSeconds(dateRange.start)}...${dateToSeconds(dateRange.end)}`)
-        .then(response => response.json())
-        .then(builds => {
-          dispatch(setBuilds(builds.map(buildStruct => new Build(buildStruct.meta, buildStruct.artifacts))));
-        })
-        .then(() => {
-          setFetchState(FetchState.FETCHED);
-        })
-        .catch(() => {
-          setFetchState(FetchState.ERROR);
-        });
-      return;
-    }
-    if (buildsCount === 0) {
-      setFetchState(FetchState.FETCHING);
-      fetch(`${url}/api/builds/${requestedBuildsCount}`)
-        .then(response => response.json())
-        .then(builds => {
-          dispatch(setBuilds(builds.map(buildStruct => new Build(buildStruct.meta, buildStruct.artifacts))));
-        })
-        .then(() => {
-          setFetchState(FetchState.FETCHED);
-        })
-        .catch(() => {
-          setFetchState(FetchState.ERROR);
-        });
-    }
-  }, [buildsCount, dateRange, dispatch, requestedBuildsCount, url]);
+  const fetchState = useSelector((state: State) => state.fetchState);
 
   return (
     <View style={styles.layout}>

--- a/src/app/src/screens/Main.tsx
+++ b/src/app/src/screens/Main.tsx
@@ -17,7 +17,9 @@ const Comparison = React.lazy(() => import(/* webpackChunkName: "Comparison" */ 
 const Main = (): React.ReactElement => {
   const drawerRef = React.useRef<DrawerHandles>(null);
 
-  const showComparisonTable = useSelector((state: State) => !!state.comparedRevisions.length);
+  const showComparisonTable = useSelector(
+    (state: State) => !!state.comparedRevisions.length && !!state.activeComparator
+  );
   const fetchState = useSelector((state: State) => state.fetchState);
 
   return (

--- a/src/app/src/screens/__tests__/Main.test.tsx
+++ b/src/app/src/screens/__tests__/Main.test.tsx
@@ -1,12 +1,8 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import * as Actions from '../../store/actions';
-import * as CrossFetch from 'cross-fetch';
 import Build from '@build-tracker/build';
 import buildA from '@build-tracker/fixtures/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
-import buildB from '@build-tracker/fixtures/builds/01141f29743fb2bdd7e176cf919fc964025cea5a.json';
-import buildC from '@build-tracker/fixtures/builds/243024909db66ac3c3e48d2ffe4015f049609834.json';
 import Comparator from '@build-tracker/comparator';
 import Comparison from '../../views/Comparison';
 import Main from '../Main';
@@ -48,101 +44,9 @@ jest.mock('../../views/Comparison', () => {
   return () => null;
 });
 
-jest.mock('cross-fetch', () => {
-  return {
-    fetch: jest.fn()
-  };
-});
-
 const url = 'https://build-tracker.local';
 
 describe('Main', () => {
-  let fetchSpy;
-  beforeEach(() => {
-    fetchSpy = jest.spyOn(CrossFetch, 'fetch').mockImplementation(() =>
-      // @ts-ignore
-      Promise.resolve({
-        json: () => [buildA, buildB, buildC]
-      })
-    );
-  });
-
-  describe('startup', () => {
-    test('fetches builds and updates', async () => {
-      const setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
-      const component = (
-        <Provider
-          store={mockStore({
-            builds: [],
-            buildCount: 10,
-            comparedRevisions: [],
-            comparator: new Comparator({ builds: [] }),
-            snacks: [],
-            url
-          })}
-        >
-          <Main />
-        </Provider>
-      );
-      const { update } = render(component);
-      update(component);
-      await flushMicrotasksQueue();
-      expect(fetchSpy).toHaveBeenCalledWith(`${url}/api/builds/10`);
-      expect(setBuildsSpy).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.any(Build), expect.any(Build), expect.any(Build)])
-      );
-    });
-
-    test('fetches builds by date and updates', async () => {
-      const setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
-      const component = (
-        <Provider
-          store={mockStore({
-            builds: [],
-            buildCount: 10,
-            comparedRevisions: [],
-            comparator: new Comparator({ builds: [] }),
-            dateRange: { start: new Date(2019, 8, 1), end: new Date(2019, 8, 15) },
-            snacks: [],
-            url
-          })}
-        >
-          <Main />
-        </Provider>
-      );
-      const { update } = render(component);
-      update(component);
-      await flushMicrotasksQueue();
-      expect(fetchSpy).toHaveBeenCalledWith(expect.stringMatching(/\/api\/builds\/time\/\d+\.\.\.\d+/));
-      expect(setBuildsSpy).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.any(Build), expect.any(Build), expect.any(Build)])
-      );
-    });
-
-    test('does not fetch builds if they already exist', async () => {
-      const setBuildsSpy = jest.spyOn(Actions, 'setBuilds');
-      const component = (
-        <Provider
-          store={mockStore({
-            builds: [buildA, buildB],
-            buildCount: 10,
-            comparedRevisions: [],
-            comparator: new Comparator({ builds: [] }),
-            snacks: [],
-            url
-          })}
-        >
-          <Main />
-        </Provider>
-      );
-      const { update } = render(component);
-      update(component);
-      await flushMicrotasksQueue();
-      expect(fetchSpy).not.toHaveBeenCalled();
-      expect(setBuildsSpy).not.toHaveBeenCalled();
-    });
-  });
-
   describe('comparison view', () => {
     test('shows when there are compared revisions', async () => {
       const store = mockStore({

--- a/src/app/src/screens/__tests__/Main.test.tsx
+++ b/src/app/src/screens/__tests__/Main.test.tsx
@@ -50,6 +50,7 @@ describe('Main', () => {
   describe('comparison view', () => {
     test('shows when there are compared revisions', async () => {
       const store = mockStore({
+        activeComparator: new Comparator({ builds: [new Build(buildA.meta, buildA.artifacts)] }),
         builds: [new Build(buildA.meta, buildA.artifacts)],
         comparedRevisions: [buildA.meta.revision],
         comparator: new Comparator({ builds: [new Build(buildA.meta, buildA.artifacts)] }),

--- a/src/app/src/store/__tests__/reducer.test.ts
+++ b/src/app/src/store/__tests__/reducer.test.ts
@@ -6,19 +6,18 @@ import Build from '@build-tracker/build';
 import ColorScale from '../../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
 import reducer from '../reducer';
-import { State } from '../types';
+import { FetchState, State } from '../types';
 
 const initialState: State = Object.freeze({
   activeArtifacts: {},
   activeComparator: null,
   artifactConfig: {},
-  buildCount: 10,
   builds: [],
   colorScale: Object.keys(ColorScale)[0],
   comparator: new Comparator({ builds: [] }),
   comparedRevisions: [],
-  dateRange: undefined,
   disabledArtifactsVisible: true,
+  fetchState: FetchState.NONE,
   hoveredArtifacts: [],
   name: 'Tacos!',
   snacks: [],
@@ -170,56 +169,6 @@ describe('reducer', () => {
       const mockState = { ...initialState, hoveredArtifacts: ['tacos', 'burritos'] };
       const state = reducer(mockState, Actions.setHoveredArtifacts(['burritos', 'tacos']));
       expect(state).toBe(mockState);
-    });
-  });
-
-  describe('date range', () => {
-    test('sets the date range', () => {
-      const start = new Date(2018);
-      const end = new Date(2019);
-      const state = reducer(initialState, Actions.setDateRange(start, end));
-      expect(state.dateRange).toEqual({ start, end });
-    });
-
-    test('clears the comparedRevisions', () => {
-      const state = reducer(
-        { ...initialState, comparedRevisions: ['123', '456', '789'] },
-        Actions.setDateRange(new Date(2017), new Date(2019))
-      );
-      expect(state.comparedRevisions).toHaveLength(0);
-    });
-
-    test('clears the builds', () => {
-      const state = reducer(
-        { ...initialState, builds: [buildA, buildB] },
-        Actions.setDateRange(new Date(2017), new Date(2019))
-      );
-      expect(state.builds).toHaveLength(0);
-    });
-  });
-
-  describe('build count', () => {
-    test('sets the build count', () => {
-      const state = reducer(initialState, Actions.setBuildCount(4));
-      expect(state.buildCount).toEqual(4);
-    });
-
-    test('clears the date range', () => {
-      const state = reducer(
-        { ...initialState, dateRange: { start: new Date(), end: new Date() } },
-        Actions.setBuildCount(4)
-      );
-      expect(state.dateRange).toBeUndefined();
-    });
-
-    test('clears the builds', () => {
-      const state = reducer({ ...initialState, builds: [buildA, buildB] }, Actions.setBuildCount(4));
-      expect(state.builds).toHaveLength(0);
-    });
-
-    test('clears the comparedRevisions', () => {
-      const state = reducer({ ...initialState, comparedRevisions: ['123', '456', '789'] }, Actions.setBuildCount(5));
-      expect(state.comparedRevisions).toHaveLength(0);
     });
   });
 

--- a/src/app/src/store/actions.ts
+++ b/src/app/src/store/actions.ts
@@ -7,14 +7,14 @@ import {
   AddComparedRevision,
   AddSnack,
   ClearComparedRevision,
+  FetchState,
   RemoveComparedRevision,
   RemoveSnack,
   SetArtifactsActiveAction,
-  SetBuildCount,
   SetBuildsAction,
   SetColorScaleAction,
-  SetDateRange,
   SetDisabledArtifactsVisible,
+  SetFetchState,
   SetFocusedRevision,
   SetHoveredArtifacts,
   SetSizeKey
@@ -75,9 +75,4 @@ export const setHoveredArtifacts = (artifactNames: Array<string>): SetHoveredArt
 
 export const setSizeKey = (key: string): SetSizeKey => ({ type: 'SET_SIZE_KEY', payload: key });
 
-export const setDateRange = (start: Date, end: Date): SetDateRange => ({
-  type: 'SET_DATE_RANGE',
-  payload: { start, end }
-});
-
-export const setBuildCount = (count: number): SetBuildCount => ({ type: 'SET_BUILD_COUNT', payload: count });
+export const setFetchState = (status: FetchState): SetFetchState => ({ type: 'SET_FETCH_STATE', payload: status });

--- a/src/app/src/store/index.ts
+++ b/src/app/src/store/index.ts
@@ -1,27 +1,35 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
+import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import ColorScale from '../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
 import reducer from './reducer';
-import { Actions, State } from './types';
+import { Actions, FetchState, State } from './types';
 import { createStore, Store } from 'redux';
 
 export default function makeStore(initialState: Partial<State> = {}): Store<State, Actions> {
-  return createStore(reducer, {
+  const store = createStore(reducer, {
     activeArtifacts: {},
     activeComparator: null,
     artifactConfig: {},
-    buildCount: 30,
     builds: [],
     colorScale: Object.keys(ColorScale)[0],
     comparator: new Comparator({ builds: [] }),
     comparedRevisions: [],
     disabledArtifactsVisible: true,
+    fetchState: FetchState.NONE,
     hoveredArtifacts: [],
     name: 'Build Tracker',
     snacks: [],
     sizeKey: '',
     ...initialState
   });
+  if (process.env.NODE_ENV !== 'production' && canUseDOM && !window.hasOwnProperty('redux')) {
+    Object.defineProperty(window, 'redux', {
+      writable: false,
+      value: store
+    });
+  }
+  return store;
 }

--- a/src/app/src/store/reducer.ts
+++ b/src/app/src/store/reducer.ts
@@ -88,11 +88,8 @@ export default function reducer(state: State, action: Actions): State {
       }
       return { ...state, hoveredArtifacts: action.payload };
 
-    case 'SET_DATE_RANGE':
-      return { ...state, builds: [], comparedRevisions: [], dateRange: action.payload };
-
-    case 'SET_BUILD_COUNT':
-      return { ...state, builds: [], comparedRevisions: [], dateRange: undefined, buildCount: action.payload };
+    case 'SET_FETCH_STATE':
+      return { ...state, fetchState: action.payload };
 
     default:
       return state;

--- a/src/app/src/store/types.ts
+++ b/src/app/src/store/types.ts
@@ -6,22 +6,23 @@ import Build from '@build-tracker/build';
 import ColorScale from '../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
 
-interface DateRange {
-  start: Date;
-  end: Date;
+export enum FetchState {
+  NONE,
+  FETCHING,
+  FETCHED,
+  ERROR
 }
 
 export interface State {
   activeArtifacts: { [key: string]: boolean };
   activeComparator: Comparator;
   artifactConfig: AppConfig['artifacts'];
-  buildCount: number;
   builds: Array<Build>;
   colorScale: keyof typeof ColorScale;
   comparator: Comparator;
   comparedRevisions: Array<string>;
-  dateRange?: DateRange;
   disabledArtifactsVisible: boolean;
+  fetchState: FetchState;
   focusedRevision?: string;
   hoveredArtifacts: Array<string>;
   name: string;
@@ -47,8 +48,7 @@ export type SetSizeKey = Action<'SET_SIZE_KEY', string>;
 export type AddSnack = Action<'ADD_SNACK', string>;
 export type RemoveSnack = Action<'REMOVE_SNACK', string>;
 export type SetHoveredArtifacts = Action<'HOVER_ARTIFACTS', Array<string>>;
-export type SetDateRange = Action<'SET_DATE_RANGE', DateRange>;
-export type SetBuildCount = Action<'SET_BUILD_COUNT', number>;
+export type SetFetchState = Action<'SET_FETCH_STATE', FetchState>;
 
 export type Actions =
   | SetArtifactsActiveAction
@@ -63,5 +63,4 @@ export type Actions =
   | AddSnack
   | RemoveSnack
   | SetHoveredArtifacts
-  | SetDateRange
-  | SetBuildCount;
+  | SetFetchState;

--- a/src/app/src/views/Drawer.tsx
+++ b/src/app/src/views/Drawer.tsx
@@ -9,30 +9,29 @@ import Divider from '../components/Divider';
 import DrawerLink from '../components/DrawerLink';
 import endOfDay from 'date-fns/end_of_day';
 import HeartIcon from '../icons/Heart';
+import history from '../client/history';
 import Logo from '../icons/Logo';
 import OpenInExternalIcon from '../icons/OpenInExternal';
-import React from 'react';
 import SizeKeyPicker from '../components/SizeKeyPicker';
 import startOfDay from 'date-fns/start_of_day';
 import { State } from '../store/types';
 import Subtitle from '../components/Subtitle';
 import TextField from '../components/TextField';
+import { clearComparedRevisions, setDisabledArtifactsVisible } from '../store/actions';
 import Drawer, { Handles as DrawerHandles } from '../components/Drawer';
-import { setBuildCount, setDateRange, setDisabledArtifactsVisible } from '../store/actions';
+import React, { FunctionComponent } from 'react';
 import { StyleSheet, Switch, Text, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 const today = new Date();
 
-const DrawerView = (_props: {}, ref: React.RefObject<DrawerHandles>): React.ReactElement => {
+const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<DrawerHandles>): React.ReactElement => {
   const comparator = useSelector((state: State) => state.comparator);
   const disabledArtifactsVisible = useSelector((state: State) => state.disabledArtifactsVisible);
-  const storeEnd = useSelector((state: State) => (state.dateRange ? state.dateRange.end : null));
-  const storeStart = useSelector((state: State) => (state.dateRange ? state.dateRange.start : null));
   const dispatch = useDispatch();
 
-  const [startDate, setStartDate] = React.useState<Date>(storeStart);
-  const [endDate, setEndDate] = React.useState<Date>(storeEnd);
+  const [startDate, setStartDate] = React.useState<Date>();
+  const [endDate, setEndDate] = React.useState<Date>();
 
   const handleToggleDisabled = React.useCallback(
     (showDisabled: boolean): void => {
@@ -42,12 +41,16 @@ const DrawerView = (_props: {}, ref: React.RefObject<DrawerHandles>): React.Reac
   );
 
   const handleSetDateRange = React.useCallback((): void => {
-    dispatch(setDateRange(startOfDay(startDate), endOfDay(endDate)));
-  }, [dispatch, startDate, endDate]);
+    const startTimestamp = Math.floor(startOfDay(startDate).valueOf() / 1000);
+    const endTimestamp = Math.floor(endOfDay(endDate).valueOf() / 1000);
+    dispatch(clearComparedRevisions());
+    history.push(`/dates/${startTimestamp}..${endTimestamp}`);
+  }, [startDate, endDate, dispatch]);
 
   const [buildCountValue, setBuildCountValue] = React.useState<string>('');
   const handleSetLastNBuilds = React.useCallback((): void => {
-    dispatch(setBuildCount(parseInt(buildCountValue, 10)));
+    dispatch(clearComparedRevisions());
+    history.push(buildCountValue ? `/builds/limit/${buildCountValue}` : '/');
   }, [buildCountValue, dispatch]);
 
   return (
@@ -165,4 +168,5 @@ const styles = StyleSheet.create({
   }
 });
 
+// @ts-ignore
 export default React.forwardRef(DrawerView);

--- a/src/app/src/views/Drawer.tsx
+++ b/src/app/src/views/Drawer.tsx
@@ -44,7 +44,7 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
     const startTimestamp = Math.floor(startOfDay(startDate).valueOf() / 1000);
     const endTimestamp = Math.floor(endOfDay(endDate).valueOf() / 1000);
     dispatch(clearComparedRevisions());
-    history.push(`/dates/${startTimestamp}..${endTimestamp}`);
+    history.push(`/builds/dates/${startTimestamp}..${endTimestamp}`);
   }, [startDate, endDate, dispatch]);
 
   const [buildCountValue, setBuildCountValue] = React.useState<string>('');
@@ -60,7 +60,7 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
         <Text style={styles.title}>Build Tracker</Text>
       </View>
 
-      <Divider />
+      <Divider style={styles.divider} />
 
       <Subtitle title="Get latest builds" />
       <TextField
@@ -72,7 +72,7 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
       />
       <Button onPress={handleSetLastNBuilds} title="Get builds" type="unelevated" />
 
-      <Divider />
+      <Divider style={styles.divider} />
 
       <Subtitle title="Date range" />
       <DateTextField maxDate={endDate || today} label="Start date" onSet={setStartDate} style={styles.textinput} />
@@ -81,13 +81,13 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
         <Button disabled={!startDate || !endDate} onPress={handleSetDateRange} title="Get range" type="unelevated" />
       </View>
 
-      <Divider />
+      <Divider style={styles.divider} />
 
       {comparator.sizeKeys.length > 1 ? (
         <>
           <Subtitle title="Compare artifacts by" />
           <SizeKeyPicker keys={comparator.sizeKeys} />
-          <Divider />
+          <Divider style={styles.divider} />
         </>
       ) : null}
 
@@ -105,11 +105,11 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
         <Text>Show disabled artifacts</Text>
       </View>
 
-      <Divider />
+      <Divider style={styles.divider} />
 
       <Subtitle title="Color scale" />
       <ColorScalePicker />
-      <Divider />
+      <Divider style={styles.divider} />
       <View style={styles.footer}>
         <Subtitle title="Links" />
         <DrawerLink href="https://buildtracker.dev" icon={OpenInExternalIcon} text="Documentation" />
@@ -145,6 +145,9 @@ const styles = StyleSheet.create({
     color: Theme.Color.Primary40,
     fontWeight: Theme.FontWeight.Bold,
     fontSize: Theme.FontSize.Large
+  },
+  divider: {
+    marginBottom: Theme.Spacing.Normal
   },
   switchRoot: {
     flexDirection: 'row',

--- a/src/app/src/views/__tests__/AppBar.test.tsx
+++ b/src/app/src/views/__tests__/AppBar.test.tsx
@@ -30,8 +30,10 @@ jest.mock('../../components/Drawer', () => {
 });
 
 const initialState = Object.freeze({
+  activeArtifacts: {},
   comparator: new Comparator({ builds: [] }),
   comparedRevisions: [],
+  disabledArtifactsVisible: true,
   sizeKey: '',
   url: 'https://build-tracker.local'
 });
@@ -147,6 +149,34 @@ describe('AppBarView', () => {
       fireEvent.press(getByProps({ title: 'More actions' }));
       fireEvent.press(getByProps({ label: 'Copy as CSV' }));
       expect(addSnackSpy).toHaveBeenCalledWith('Copied table as CSV');
+    });
+
+    test('can copy link and adds query params', () => {
+      const { getByProps } = render(
+        <Provider store={mockStore({ ...seededState, activeArtifacts: { main: true, vendor: false, shared: true } })}>
+          <AppBarView drawerRef={drawerRef} />
+        </Provider>
+      );
+
+      fireEvent.press(getByProps({ title: 'More actions' }));
+      fireEvent.press(getByProps({ label: 'Copy link' }));
+
+      expect(clipboardSpy).toHaveBeenCalledWith(
+        'https://build-tracker.local/?sizeKey=gzip&disabledArtifactsVisible=true&comparedRevisions=22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04&comparedRevisions=01141f29743fb2bdd7e176cf919fc964025cea5a&activeArtifacts=main&activeArtifacts=shared'
+      );
+    });
+
+    test('shows a message when link is copied', () => {
+      const addSnackSpy = jest.spyOn(Actions, 'addSnack');
+      const { getByProps } = render(
+        <Provider store={mockStore(seededState)}>
+          <AppBarView drawerRef={drawerRef} />
+        </Provider>
+      );
+
+      fireEvent.press(getByProps({ title: 'More actions' }));
+      fireEvent.press(getByProps({ label: 'Copy link' }));
+      expect(addSnackSpy).toHaveBeenCalledWith('Copied link to clipboard');
     });
   });
 });

--- a/src/server/src/types.ts
+++ b/src/server/src/types.ts
@@ -15,7 +15,7 @@ export interface Queries {
     insert: (build: Build) => Promise<string>;
   };
   builds: {
-    byRevisions: (...revisions: Array<string>) => Promise<Array<Build>>;
+    byRevisions: (revisions: Array<string>) => Promise<Array<Build>>;
     byRevisionRange: (startRevision: string, endRevision: string) => Promise<Array<Build>>;
     byTimeRange: (startTimestamp: number, endTimestamp: number, branch: string) => Promise<Array<Build>>;
     recent: (limit: number, branch: string) => Promise<Array<Build>>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,7 +719,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.5.5":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.4.0", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -1886,6 +1886,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/history@*":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
+  integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
+
 "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2034,6 +2039,14 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
+
+"@types/react-router@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.0.3.tgz#855a1606e62de3f4d69ea34fb3c0e50e98e964d5"
+  integrity sha512-j2Gge5cvxca+5lK9wxovmGPgpVJMwjyu5lTA/Cd6fLGoPq7FXcUE1jFkEdxeyqGGz8VfHYSHCn5Lcn24BzaNKA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.8.3":
   version "16.8.23"
@@ -6521,6 +6534,11 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 gzip-size@5.1.1, gzip-size@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -6697,6 +6715,18 @@ highlight.js@^9.15.8:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
   integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
 
+history@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^0.4.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -6706,7 +6736,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -7646,6 +7676,11 @@ is2@2.0.1:
     deep-is "^0.1.3"
     ip-regex "^2.1.0"
     is-url "^1.2.2"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -8703,7 +8738,7 @@ longest@^1.0.0:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9064,6 +9099,15 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -10269,6 +10313,13 @@ path-to-regexp@3.0.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.0.0.tgz#c981a218f3df543fa28696be2f88e0c58d2e012a"
   integrity sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -11203,7 +11254,7 @@ react-error-overlay@^6.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.1.tgz#b8d3cf9bb991c02883225c48044cb3ee20413e0f"
   integrity sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==
 
-react-is@^16.7.0, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.4, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -11247,6 +11298,22 @@ react-redux@^7.1.1:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-router@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"
+  integrity sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-test-renderer@^16.8.3:
   version "16.8.6"
@@ -11688,6 +11755,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -12962,6 +13034,11 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tiny-invariant@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
+
 tiny-lr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tiny-lr/-/tiny-lr-1.1.1.tgz#9fa547412f238fedb068ee295af8b682c98b2aab"
@@ -12973,6 +13050,11 @@ tiny-lr@^1.1.1:
     livereload-js "^2.3.0"
     object-assign "^4.1.0"
     qs "^6.4.0"
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -13546,6 +13628,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

It's not possible to do the following:
* Share your view with someone else
* Link directly to specific build comparisons

Fixes #10, #43

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

* Use `react-router`
* Remove date range and build count from redux store, rely on URL routing for those params
* Split the fetching of data into separate routes from the top level of the client

# TODO

- [x] Add "Copy link to view" to action menu
- [x] Add query param linking for compared revisions
- [x] Add query param linking for enabled artifacts
- [x] Add query param linking for `sizeKey`
- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
