### PR TITLE
[app] add stacked bar chart option

### DIFF
--- a/src/app/src/client/index.tsx
+++ b/src/app/src/client/index.tsx
@@ -18,6 +18,7 @@ const objParams = {
   activeArtifacts: params
     .getAll('activeArtifacts')
     .reduce((memo, artifactName) => ({ ...memo, [artifactName]: true }), {}),
+  graphType: params.get('graphType'),
   sizeKey: params.get('sizeKey'),
   disabledArtifactsVisible: params.get('disabledArtifactsVisible') === 'false' ? false : true,
   comparedRevisions: params.getAll('comparedRevisions') || []

--- a/src/app/src/components/Graph/StackedBar.tsx
+++ b/src/app/src/components/Graph/StackedBar.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import 'd3-transition';
+import Build from '@build-tracker/build';
+import { hsl } from 'd3-color';
+import React from 'react';
+import { select } from 'd3-selection';
+import { Series } from 'd3-shape';
+import { ScaleBand, ScaleLinear, ScaleSequential } from 'd3-scale';
+
+interface Props {
+  activeArtifactNames: Array<string>;
+  artifactNames: Array<string>;
+  colorScale: ScaleSequential<string>;
+  data: Array<Series<Build, string>>;
+  height: number;
+  hoveredArtifacts: Array<string>;
+  xScale: ScaleBand<string>;
+  yScale: ScaleLinear<number, number>;
+}
+
+const Area = (props: Props): React.ReactElement => {
+  const { activeArtifactNames, artifactNames, colorScale, data, height, hoveredArtifacts, xScale, yScale } = props;
+
+  const gRef = React.useRef(null);
+
+  const graphColorScale = React.useMemo(() => {
+    return d => {
+      const color = hsl(colorScale(artifactNames.indexOf(d.key)));
+      if (hoveredArtifacts.length && !hoveredArtifacts.includes(d.key)) {
+        color.l = 0.75;
+        color.s = 0.4;
+      }
+      return color.toString();
+    };
+  }, [colorScale, artifactNames, hoveredArtifacts]);
+
+  React.useEffect(() => {
+    const contents = select(gRef.current);
+
+    const groups = contents.selectAll('g.artifactGroup').data(data, (d: { key: string }): string => d.key);
+    groups
+      .transition()
+      .duration(150)
+      .style('fill', graphColorScale);
+
+    groups.exit().remove();
+
+    const rects = groups
+      .enter()
+      .append('g')
+      .attr('class', 'artifactGroup')
+      .attr('aria-label', d => d.key)
+      .style('fill', graphColorScale)
+      // @ts-ignore
+      .merge(groups)
+      .selectAll('rect.artifact')
+      .data(d => d);
+
+    rects.exit().remove();
+
+    rects
+      .enter()
+      .append('rect')
+      .attr('class', 'artifact')
+      .attr('x', d => xScale(d.data.getMetaValue('revision')))
+      .attr('y', () => height)
+      .attr('width', xScale.bandwidth())
+      .attr('height', 0)
+      .merge(rects)
+      .transition()
+      .duration(150)
+      .attr('x', d => xScale(d.data.getMetaValue('revision')))
+      .attr('y', d => yScale(d[1]))
+      .attr('height', d => yScale(d[0]) - yScale(d[1]))
+      .attr('width', xScale.bandwidth());
+  }, [data, graphColorScale, height, xScale, yScale]);
+
+  return <g aria-label={`Stacked bar chart for ${activeArtifactNames.join(', ')}`} pointerEvents="all" ref={gRef} />;
+};
+
+export default Area;

--- a/src/app/src/components/Graph/__tests__/StackedBar.test.tsx
+++ b/src/app/src/components/Graph/__tests__/StackedBar.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import Build from '@build-tracker/build';
+import ColorScale from '../../../modules/ColorScale';
+import Comparator from '@build-tracker/comparator';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { stack } from 'd3-shape';
+import StackedBar from '../StackedBar';
+import { timerFlush } from 'd3-timer';
+import { scaleBand, scaleLinear } from 'd3-scale';
+
+describe('StackedBar', () => {
+  test('only draws the active artifacts', () => {
+    const builds = [
+      new Build({ branch: 'master', revision: '123', parentRevision: '000', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { gzip: 123 } },
+        { name: 'vendor', hash: '123', sizes: { gzip: 123 } }
+      ]),
+      new Build({ branch: 'master', revision: 'abc', parentRevision: '123', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { gzip: 123 } },
+        { name: 'vendor', hash: '123', sizes: { gzip: 123 } }
+      ])
+    ];
+    const comparator = new Comparator({ builds });
+
+    const dataStack = stack<Build, string>();
+    dataStack.keys(['main']);
+    dataStack.value((build: Build, key) => {
+      const artifact = build.getArtifact(key);
+      return artifact ? artifact.sizes['gzip'] : 0;
+    });
+    const data = dataStack(comparator.builds);
+
+    const xScale = scaleBand()
+      .rangeRound([0, 100])
+      .domain(['123', 'abc']);
+    const yScale = scaleLinear()
+      .range([400, 0])
+      .domain([0, 400]);
+    const { getByLabelText } = render(
+      <svg>
+        <StackedBar
+          activeArtifactNames={['main']}
+          artifactNames={comparator.artifactNames}
+          colorScale={ColorScale.Cool}
+          data={data}
+          height={400}
+          hoveredArtifacts={[]}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </svg>
+    );
+    timerFlush();
+    const wrapper = getByLabelText('Stacked bar chart for main');
+    expect(wrapper.children).toHaveLength(1);
+    expect(getByLabelText('main').getAttribute('style')).toEqual('fill: rgb(110, 64, 170);');
+  });
+
+  test('can render if an artifact does not exist in a build', () => {
+    const builds = [
+      new Build({ branch: 'master', revision: '123', parentRevision: '000', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 456 } }
+      ]),
+      new Build({ branch: 'master', revision: 'abc', parentRevision: '123', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 489 } },
+        { name: 'vendor', hash: '123', sizes: { stat: 123 } }
+      ])
+    ];
+    const comparator = new Comparator({ builds });
+
+    const dataStack = stack<Build, string>();
+    dataStack.keys(['main', 'vendor']);
+    dataStack.value((build: Build, key) => {
+      const artifact = build.getArtifact(key);
+      return artifact ? artifact.sizes['stat'] : 0;
+    });
+    const data = dataStack(comparator.builds);
+
+    const xScale = scaleBand()
+      .rangeRound([0, 100])
+      .domain(['123', 'abc']);
+    const yScale = scaleLinear()
+      .range([400, 0])
+      .domain([0, 400]);
+    const { getByLabelText } = render(
+      <svg>
+        <StackedBar
+          activeArtifactNames={['main', 'vendor']}
+          artifactNames={comparator.artifactNames}
+          colorScale={ColorScale.Cool}
+          data={data}
+          height={400}
+          hoveredArtifacts={[]}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </svg>
+    );
+    timerFlush();
+    const wrapper = getByLabelText('Stacked bar chart for main, vendor');
+    expect(wrapper.children).toHaveLength(2);
+    expect(wrapper.children[0].nodeName).toEqual('g');
+    expect(wrapper.children[1].nodeName).toEqual('g');
+    expect(getByLabelText('vendor').getAttribute('style')).toEqual('fill: rgb(175, 240, 91);');
+    expect(getByLabelText('main').getAttribute('style')).toEqual('fill: rgb(110, 64, 170);');
+  });
+
+  test('reduces luminance of non-hovered artifacts', () => {
+    const builds = [
+      new Build({ branch: 'master', revision: '123', parentRevision: '000', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 456 } },
+        { name: 'vendor', hash: '123', sizes: { stat: 123 } }
+      ]),
+      new Build({ branch: 'master', revision: 'abc', parentRevision: '123', timestamp: 0 }, [
+        { name: 'main', hash: '123', sizes: { stat: 489 } },
+        { name: 'vendor', hash: '123', sizes: { stat: 123 } }
+      ])
+    ];
+    const comparator = new Comparator({ builds });
+
+    const dataStack = stack<Build, string>();
+    dataStack.keys(['main', 'vendor']);
+    dataStack.value((build: Build, key) => {
+      const artifact = build.getArtifact(key);
+      return artifact ? artifact.sizes['gzip'] : 0;
+    });
+    const data = dataStack(comparator.builds);
+
+    const xScale = scaleBand()
+      .rangeRound([0, 100])
+      .domain(['123', 'abc']);
+    const yScale = scaleLinear()
+      .range([400, 0])
+      .domain([0, 400]);
+    const { getByLabelText } = render(
+      <svg>
+        <StackedBar
+          activeArtifactNames={['main', 'vendor']}
+          artifactNames={comparator.artifactNames}
+          colorScale={ColorScale.Cool}
+          data={data}
+          height={400}
+          hoveredArtifacts={['vendor']}
+          xScale={xScale}
+          yScale={yScale}
+        />
+      </svg>
+    );
+    timerFlush();
+
+    expect(getByLabelText('main').getAttribute('style')).toEqual('fill: rgb(188, 166, 217);');
+    expect(getByLabelText('vendor').getAttribute('style')).toEqual('fill: rgb(175, 240, 91);');
+  });
+});

--- a/src/app/src/components/Graph/__tests__/index.test.tsx
+++ b/src/app/src/components/Graph/__tests__/index.test.tsx
@@ -1,14 +1,17 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
+import Area from '../Area';
 import Build from '@build-tracker/build';
 import buildDataA from '@build-tracker/fixtures/builds/30af629d1d4c9f2f199cec5f572a019d4198004c.json';
 import buildDataB from '@build-tracker/fixtures/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
 import buildDataC from '@build-tracker/fixtures/builds/243024909db66ac3c3e48d2ffe4015f049609834.json';
 import Comparator from '@build-tracker/comparator';
+import { GraphType } from '../../../store/types';
 import mockStore from '../../../store/mock';
 import { Provider } from 'react-redux';
 import React from 'react';
+import StackedBar from '../StackedBar';
 import { View } from 'react-native';
 import { fireEvent, render } from 'react-native-testing-library';
 import Graph, { SVG } from '../';
@@ -29,6 +32,7 @@ describe('Graph', () => {
           colorScale: 'Magma',
           comparator,
           comparedRevisions: [],
+          graphType: GraphType.AREA,
           hoveredArtifacts: [],
           sizeKey: 'stat'
         })}
@@ -40,5 +44,47 @@ describe('Graph', () => {
     const svg = getByType(SVG);
     expect(svg.props.width).toEqual(400);
     expect(svg.props.height).toEqual(300);
+  });
+
+  test('creates an area chart if store is set to area', () => {
+    const comparator = new Comparator({ builds: builds });
+    const { getByType } = render(
+      <Provider
+        store={mockStore({
+          activeArtifacts: { main: true },
+          colorScale: 'Magma',
+          comparator,
+          comparedRevisions: [],
+          graphType: GraphType.AREA,
+          hoveredArtifacts: [],
+          sizeKey: 'stat'
+        })}
+      >
+        <Graph comparator={comparator} />
+      </Provider>
+    );
+    fireEvent(getByType(View), 'layout', { nativeEvent: { layout: { width: 400, height: 300 } } });
+    expect(getByType(Area)).not.toBeUndefined();
+  });
+
+  test('creates an stacked bar chart if store is set to stacked bar', () => {
+    const comparator = new Comparator({ builds: builds });
+    const { getByType } = render(
+      <Provider
+        store={mockStore({
+          activeArtifacts: { main: true },
+          colorScale: 'Magma',
+          comparator,
+          comparedRevisions: [],
+          graphType: GraphType.STACKED_BAR,
+          hoveredArtifacts: [],
+          sizeKey: 'stat'
+        })}
+      >
+        <Graph comparator={comparator} />
+      </Provider>
+    );
+    fireEvent(getByType(View), 'layout', { nativeEvent: { layout: { width: 400, height: 300 } } });
+    expect(getByType(StackedBar)).not.toBeUndefined();
   });
 });

--- a/src/app/src/icons/BarChart.tsx
+++ b/src/app/src/icons/BarChart.tsx
@@ -1,0 +1,32 @@
+/**
+ * Material design redistributed from https://github.com/google/material-design-icons
+ *
+ * SVG contents redistributed under Apache License 2.0:
+ * https://github.com/google/material-design-icons/blob/master/LICENSE
+ * Copyright 2015 Google, Inc. All Rights Reserved.
+ */
+import React from 'react';
+import styles from './styles';
+import { createElement, StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+interface Props {
+  style?: StyleProp<ViewStyle & TextStyle>;
+}
+
+const BarChart = (props: Props): React.ReactElement<Props> =>
+  createElement(
+    'svg',
+    {
+      ...props,
+      style: [styles.root, props.style],
+      viewBox: '0 0 24 24'
+    },
+    <g>
+      <path d="M5 9.2h3V19H5zM10.6 5h2.8v14h-2.8zm5.6 8H19v6h-2.8z" />
+      <path fill="none" d="M0 0h24v24H0z" />
+    </g>
+  );
+
+BarChart.metadata = { height: 24, width: 24 };
+
+export default BarChart;

--- a/src/app/src/icons/LineChart.tsx
+++ b/src/app/src/icons/LineChart.tsx
@@ -1,0 +1,32 @@
+/**
+ * Material design redistributed from https://github.com/google/material-design-icons
+ *
+ * SVG contents redistributed under Apache License 2.0:
+ * https://github.com/google/material-design-icons/blob/master/LICENSE
+ * Copyright 2015 Google, Inc. All Rights Reserved.
+ */
+import React from 'react';
+import styles from './styles';
+import { createElement, StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+interface Props {
+  style?: StyleProp<ViewStyle & TextStyle>;
+}
+
+const LineChart = (props: Props): React.ReactElement<Props> =>
+  createElement(
+    'svg',
+    {
+      ...props,
+      style: [styles.root, props.style],
+      viewBox: '0 0 24 24'
+    },
+    <g>
+      <path d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z" />
+      <path fill="none" d="M0 0h24v24H0z" />
+    </g>
+  );
+
+LineChart.metadata = { height: 24, width: 24 };
+
+export default LineChart;

--- a/src/app/src/store/__tests__/reducer.test.ts
+++ b/src/app/src/store/__tests__/reducer.test.ts
@@ -6,7 +6,7 @@ import Build from '@build-tracker/build';
 import ColorScale from '../../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
 import reducer from '../reducer';
-import { FetchState, State } from '../types';
+import { FetchState, GraphType, State } from '../types';
 
 const initialState: State = Object.freeze({
   activeArtifacts: {},
@@ -18,6 +18,7 @@ const initialState: State = Object.freeze({
   comparedRevisions: [],
   disabledArtifactsVisible: true,
   fetchState: FetchState.NONE,
+  graphType: GraphType.AREA,
   hoveredArtifacts: [],
   name: 'Tacos!',
   snacks: [],
@@ -91,6 +92,11 @@ describe('reducer', () => {
     test('resets the sizeKey if it the current is not in the new set', () => {
       const state = reducer({ ...initialState, sizeKey: 'foobar' }, Actions.setBuilds([buildA, buildB]));
       expect(state.sizeKey).toBe('gzip');
+    });
+
+    test('sets graph type to bar if 10 or fewer builds', () => {
+      const state = reducer({ ...initialState, sizeKey: 'foobar' }, Actions.setBuilds([buildA, buildB]));
+      expect(state.graphType).toBe(GraphType.STACKED_BAR);
     });
   });
 
@@ -202,6 +208,13 @@ describe('reducer', () => {
       const mockState = { ...initialState, hoveredArtifacts: ['tacos', 'burritos'] };
       const state = reducer(mockState, Actions.setHoveredArtifacts(['burritos', 'tacos']));
       expect(state).toBe(mockState);
+    });
+  });
+
+  describe('set graph type', () => {
+    test('can be set', () => {
+      const state = reducer(initialState, Actions.setGraphType(GraphType.STACKED_BAR));
+      expect(state.graphType).toEqual(GraphType.STACKED_BAR);
     });
   });
 

--- a/src/app/src/store/actions.ts
+++ b/src/app/src/store/actions.ts
@@ -8,6 +8,7 @@ import {
   AddSnack,
   ClearComparedRevision,
   FetchState,
+  GraphType,
   RemoveComparedRevision,
   RemoveSnack,
   SetArtifactsActiveAction,
@@ -16,6 +17,7 @@ import {
   SetDisabledArtifactsVisible,
   SetFetchState,
   SetFocusedRevision,
+  SetGraphType,
   SetHoveredArtifacts,
   SetSizeKey
 } from './types';
@@ -76,3 +78,5 @@ export const setHoveredArtifacts = (artifactNames: Array<string>): SetHoveredArt
 export const setSizeKey = (key: string): SetSizeKey => ({ type: 'SET_SIZE_KEY', payload: key });
 
 export const setFetchState = (status: FetchState): SetFetchState => ({ type: 'SET_FETCH_STATE', payload: status });
+
+export const setGraphType = (graphType: GraphType): SetGraphType => ({ type: 'SET_GRAPH_TYPE', payload: graphType });

--- a/src/app/src/store/index.ts
+++ b/src/app/src/store/index.ts
@@ -5,7 +5,7 @@ import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import ColorScale from '../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
 import reducer from './reducer';
-import { Actions, FetchState, State } from './types';
+import { Actions, FetchState, GraphType, State } from './types';
 import { createStore, Store } from 'redux';
 
 export default function makeStore(initialState: Partial<State> = {}): Store<State, Actions> {
@@ -19,6 +19,7 @@ export default function makeStore(initialState: Partial<State> = {}): Store<Stat
     comparedRevisions: [],
     disabledArtifactsVisible: true,
     fetchState: FetchState.NONE,
+    graphType: GraphType.AREA,
     hoveredArtifacts: [],
     name: 'Build Tracker',
     snacks: [],

--- a/src/app/src/store/reducer.ts
+++ b/src/app/src/store/reducer.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 Paul Armstrong
  */
 import Comparator from '@build-tracker/comparator';
-import { Actions, State } from './types';
+import { Actions, GraphType, State } from './types';
 
 const getActiveComparator = (
   comparedRevisions: State['comparedRevisions'],
@@ -44,8 +44,10 @@ export default function reducer(state: State, action: Actions): State {
         ? getActiveComparator(state.comparedRevisions, builds, state.artifactConfig)
         : null;
 
+      const graphType = builds.length <= 10 ? GraphType.STACKED_BAR : state.graphType;
+
       const sizeKey = comparator.sizeKeys.includes(state.sizeKey) ? state.sizeKey : comparator.sizeKeys[0];
-      return { ...state, activeComparator, activeArtifacts, builds, comparator, sizeKey };
+      return { ...state, activeComparator, activeArtifacts, builds, comparator, graphType, sizeKey };
     }
 
     case 'COLOR_SCALE_SET':
@@ -99,6 +101,9 @@ export default function reducer(state: State, action: Actions): State {
 
     case 'SET_FETCH_STATE':
       return { ...state, fetchState: action.payload };
+
+    case 'SET_GRAPH_TYPE':
+      return { ...state, graphType: action.payload };
 
     default:
       return state;

--- a/src/app/src/store/types.ts
+++ b/src/app/src/store/types.ts
@@ -13,6 +13,11 @@ export enum FetchState {
   ERROR
 }
 
+export enum GraphType {
+  AREA = 'area',
+  STACKED_BAR = 'bar'
+}
+
 export interface State {
   activeArtifacts: { [key: string]: boolean };
   activeComparator: Comparator;
@@ -24,6 +29,7 @@ export interface State {
   disabledArtifactsVisible: boolean;
   fetchState: FetchState;
   focusedRevision?: string;
+  graphType: GraphType;
   hoveredArtifacts: Array<string>;
   name: string;
   snacks: Array<string>;
@@ -49,6 +55,7 @@ export type AddSnack = Action<'ADD_SNACK', string>;
 export type RemoveSnack = Action<'REMOVE_SNACK', string>;
 export type SetHoveredArtifacts = Action<'HOVER_ARTIFACTS', Array<string>>;
 export type SetFetchState = Action<'SET_FETCH_STATE', FetchState>;
+export type SetGraphType = Action<'SET_GRAPH_TYPE', GraphType>;
 
 export type Actions =
   | SetArtifactsActiveAction
@@ -63,4 +70,5 @@ export type Actions =
   | AddSnack
   | RemoveSnack
   | SetHoveredArtifacts
-  | SetFetchState;
+  | SetFetchState
+  | SetGraphType;

--- a/src/app/src/views/AppBar.tsx
+++ b/src/app/src/views/AppBar.tsx
@@ -25,6 +25,8 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
   const name = useSelector((state: State) => state.name);
   const sizeKey = useSelector((state: State) => state.sizeKey || state.comparator.sizeKeys[0]);
   const disabledArtifactsVisible = useSelector((state: State) => state.disabledArtifactsVisible);
+  const graphType = useSelector((state: State) => state.graphType);
+
   const dispatch = useDispatch();
 
   const appBarRef = React.useRef<AppBarHandles>(null);
@@ -72,6 +74,7 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
     const params = new URLSearchParams();
     params.append('sizeKey', sizeKey);
     params.append('disabledArtifactsVisible', `${disabledArtifactsVisible}`);
+    params.append('graphType', `${graphType}`);
     comparedRevisions.forEach(rev => {
       params.append('comparedRevisions', rev);
     });
@@ -88,7 +91,7 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
     Clipboard.setString(newUrl.toString());
     dispatch(addSnack('Copied link to clipboard'));
     appBarRef.current.dismissOverflow();
-  }, [disabledArtifactsVisible, dispatch, sizeKey, activeArtifacts, comparedRevisions]);
+  }, [sizeKey, disabledArtifactsVisible, graphType, comparedRevisions, activeArtifacts, dispatch]);
 
   return (
     <AppBar

--- a/src/app/src/views/Drawer.tsx
+++ b/src/app/src/views/Drawer.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 Paul Armstrong
  */
 import * as Theme from '../theme';
+import BarChartIcon from '../icons/BarChart';
 import Button from '../components/Button';
 import ColorScalePicker from '../components/ColorScalePicker';
 import DateTextField from '../components/DateTextField';
@@ -10,15 +11,16 @@ import DrawerLink from '../components/DrawerLink';
 import endOfDay from 'date-fns/end_of_day';
 import HeartIcon from '../icons/Heart';
 import history from '../client/history';
+import LineChartIcon from '../icons/LineChart';
 import Logo from '../icons/Logo';
 import OpenInExternalIcon from '../icons/OpenInExternal';
 import SizeKeyPicker from '../components/SizeKeyPicker';
 import startOfDay from 'date-fns/start_of_day';
-import { State } from '../store/types';
 import Subtitle from '../components/Subtitle';
 import TextField from '../components/TextField';
-import { clearComparedRevisions, setDisabledArtifactsVisible } from '../store/actions';
+import { clearComparedRevisions, setDisabledArtifactsVisible, setGraphType } from '../store/actions';
 import Drawer, { Handles as DrawerHandles } from '../components/Drawer';
+import { GraphType, State } from '../store/types';
 import React, { FunctionComponent } from 'react';
 import { StyleSheet, Switch, Text, View } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -28,6 +30,8 @@ const today = new Date();
 const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<DrawerHandles>): React.ReactElement => {
   const comparator = useSelector((state: State) => state.comparator);
   const disabledArtifactsVisible = useSelector((state: State) => state.disabledArtifactsVisible);
+  const graphType = useSelector((state: State) => state.graphType);
+
   const dispatch = useDispatch();
 
   const [startDate, setStartDate] = React.useState<Date>();
@@ -52,6 +56,13 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
     dispatch(clearComparedRevisions());
     history.push(buildCountValue ? `/builds/limit/${buildCountValue}` : '/');
   }, [buildCountValue, dispatch]);
+
+  const handleSetGraphArea = React.useCallback((): void => {
+    dispatch(setGraphType(GraphType.AREA));
+  }, [dispatch]);
+  const handleSetGraphBar = React.useCallback((): void => {
+    dispatch(setGraphType(GraphType.STACKED_BAR));
+  }, [dispatch]);
 
   return (
     <Drawer hidden ref={ref}>
@@ -107,6 +118,25 @@ const DrawerView: FunctionComponent<{}> = (_props: {}, ref: React.RefObject<Draw
 
       <Divider style={styles.divider} />
 
+      <View style={styles.buttonRow}>
+        <Button
+          disabled={graphType === GraphType.AREA}
+          icon={LineChartIcon}
+          onPress={handleSetGraphArea}
+          title="Area"
+          type={graphType === GraphType.AREA ? 'unelevated' : 'text'}
+        />
+        <Button
+          disabled={graphType === GraphType.STACKED_BAR}
+          icon={BarChartIcon}
+          onPress={handleSetGraphBar}
+          title="Stacked Bar"
+          type={graphType === GraphType.STACKED_BAR ? 'unelevated' : 'text'}
+        />
+      </View>
+
+      <Divider style={styles.divider} />
+
       <Subtitle title="Color scale" />
       <ColorScalePicker />
       <Divider style={styles.divider} />
@@ -155,6 +185,11 @@ const styles = StyleSheet.create({
   },
   switch: {
     marginEnd: Theme.Spacing.Small
+  },
+  buttonRow: {
+    justifyContent: 'space-around',
+    flexDirection: 'row',
+    marginBottom: Theme.Spacing.Normal
   },
   textinput: {
     marginBottom: Theme.Spacing.Small

--- a/src/app/src/views/__tests__/AppBar.test.tsx
+++ b/src/app/src/views/__tests__/AppBar.test.tsx
@@ -10,6 +10,7 @@ import buildB from '@build-tracker/fixtures/builds/01141f29743fb2bdd7e176cf919fc
 import { Clipboard } from 'react-native';
 import Comparator from '@build-tracker/comparator';
 import Drawer from '../../components/Drawer';
+import { GraphType } from '../../store/types';
 import mockStore from '../../store/mock';
 import { Provider } from 'react-redux';
 import React from 'react';
@@ -34,6 +35,7 @@ const initialState = Object.freeze({
   comparator: new Comparator({ builds: [] }),
   comparedRevisions: [],
   disabledArtifactsVisible: true,
+  graphType: GraphType.AREA,
   sizeKey: '',
   url: 'https://build-tracker.local'
 });
@@ -162,7 +164,7 @@ describe('AppBarView', () => {
       fireEvent.press(getByProps({ label: 'Copy link' }));
 
       expect(clipboardSpy).toHaveBeenCalledWith(
-        'https://build-tracker.local/?sizeKey=gzip&disabledArtifactsVisible=true&comparedRevisions=22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04&comparedRevisions=01141f29743fb2bdd7e176cf919fc964025cea5a&activeArtifacts=main&activeArtifacts=shared'
+        'https://build-tracker.local/?sizeKey=gzip&disabledArtifactsVisible=true&graphType=area&comparedRevisions=22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04&comparedRevisions=01141f29743fb2bdd7e176cf919fc964025cea5a&activeArtifacts=main&activeArtifacts=shared'
       );
     });
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Viewing area charts for small numbers of revisions makes it difficult to discern differences

# Solution

Add a _Stacked Bar_ graph option.

* Persists when copying links
* Defaults to stacked view when receiving 10 or fewer builds
* Can be toggled via the _Drawer_

Fixes #91 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
