### PR TITLE
Fix upload build response

### DIFF
--- a/src/cli/src/commands/__tests__/upload-build.test.ts
+++ b/src/cli/src/commands/__tests__/upload-build.test.ts
@@ -50,6 +50,19 @@ describe('upload-build', () => {
       expect(writeSpy).toHaveBeenCalledWith('{"success":"yep"}');
     });
 
+    test('invokes `onCompare`', async () => {
+      jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
+      const configValues = require(config);
+      const onCompareSpy = jest.spyOn(configValues, 'onCompare').mockImplementationOnce(() => Promise.resolve());
+
+      nock(`${configValues.applicationUrl}/`)
+        .post('/api/builds')
+        .reply(200, { success: 'yep' });
+
+      await expect(Command.handler({ config, out: true, 'skip-dirty-check': true })).resolves.toBeUndefined();
+      expect(onCompareSpy).toHaveBeenCalledWith({ success: 'yep' });
+    });
+
     test('uploads the current build over http', async () => {
       jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
       const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -3,7 +3,7 @@
  */
 import { Argv } from 'yargs';
 import { handler as createBuild } from './create-build';
-import getConfig from '../modules/config';
+import getConfig, { ApiReturn } from '../modules/config';
 import http from 'http';
 import https from 'https';
 import { URL } from 'url';
@@ -76,7 +76,7 @@ export const handler = async (args: Args): Promise<void> => {
       });
 
       res.on('end', () => {
-        const response = Buffer.from(output).toJSON();
+        const response = JSON.parse(output.join('')) as ApiReturn;
         if (config.onCompare) {
           // @ts-ignore
           config.onCompare(response).then(resolve);

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -78,7 +78,6 @@ export const handler = async (args: Args): Promise<void> => {
       res.on('end', () => {
         const response = JSON.parse(output.join('')) as ApiReturn;
         if (config.onCompare) {
-          // @ts-ignore
           config.onCompare(response).then(resolve);
         } else {
           resolve();

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -3,10 +3,10 @@
  */
 import { Argv } from 'yargs';
 import { handler as createBuild } from './create-build';
-import getConfig, { ApiReturn } from '../modules/config';
 import http from 'http';
 import https from 'https';
 import { URL } from 'url';
+import getConfig, { ApiReturn } from '../modules/config';
 
 export const command = 'upload-build';
 

--- a/src/cli/src/modules/config.ts
+++ b/src/cli/src/modules/config.ts
@@ -10,7 +10,7 @@ interface BuildJson {
   artifacts: Array<Artifact<ArtifactSizes>>;
 }
 
-interface ApiReturn {
+export interface ApiReturn {
   build: BuildJson;
   parentBuild: BuildJson;
   json: ComparisonMatrix;

--- a/src/fixtures/cli-configs/rc/.build-trackerrc.js
+++ b/src/fixtures/cli-configs/rc/.build-trackerrc.js
@@ -4,5 +4,6 @@ module.exports = {
   applicationUrl: 'https://build-tracker.local',
   artifacts: ['../fakedist/*.js'],
   baseDir: path.resolve(__dirname, 'fakedist'),
-  cwd: __dirname
+  cwd: __dirname,
+  onCompare: data => Promise.resolve()
 };


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

The value of `response` that's passed into `onCompare` does not match the param type (`ApiReturn`).

```sh-session
$ node
> Buffer.from(['{"success":"yep"}']).toJSON()
{ type: 'Buffer', data: [ 0 ] }
```

I had to make this change to get it working.

I don't understand how the tests are passing?

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
