### PR TITLE
Fix config error

### DIFF
--- a/src/cli/src/modules/__tests__/config.test.ts
+++ b/src/cli/src/modules/__tests__/config.test.ts
@@ -31,6 +31,14 @@ describe('getConfig', () => {
     });
   });
 
+  test('propagate errors', () => {
+    return getConfig(
+      path.join(path.dirname(require.resolve('@build-tracker/fixtures')), 'cli-configs/rc/.build-trackerrc-invalid.js')
+    ).catch(e => {
+      expect(e.message).toMatch('test');
+    });
+  });
+
   test('throws if no configuration found', () => {
     return getConfig('tacos').catch(e => {
       expect(e.message).toMatch('Could not find configuration file');

--- a/src/cli/src/modules/config.ts
+++ b/src/cli/src/modules/config.ts
@@ -35,7 +35,11 @@ export default async function getConfig(path?: string): Promise<Config> {
   try {
     result = !path ? await explorer.search() : await explorer.load(path);
   } catch (e) {
-    throw new Error('Could not find configuration file');
+    if (e.code === 'ENOENT') {
+      throw new Error('Could not find configuration file');
+    } else {
+      throw e;
+    }
   }
 
   return {

--- a/src/fixtures/cli-configs/rc/.build-trackerrc-invalid.js
+++ b/src/fixtures/cli-configs/rc/.build-trackerrc-invalid.js
@@ -1,0 +1,1 @@
+throw new Error('test');


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Currently, if the config file errors, the CLI will return a generic error message: "Could not find configuration file". However this is misleading, because the config _was_ found.

With this PR, we only use this error message when the config file was genuinely not found. Otherwise we use the error that came from the config file.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
