### PR TITLE
[app] Add ellipsis to long ArtifactCells

### DIFF
--- a/src/app/src/components/ComparisonTable/ArtifactCell.tsx
+++ b/src/app/src/components/ComparisonTable/ArtifactCell.tsx
@@ -6,6 +6,7 @@ import Hoverable from '../Hoverable';
 import { hsl } from 'd3-color';
 import React from 'react';
 import { Th } from '../Table';
+import Tooltip from '../Tooltip';
 import { ArtifactCell as ACell, GroupCell as GCell } from '@build-tracker/comparator';
 import { StyleProp, StyleSheet, Switch, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 
@@ -35,6 +36,8 @@ export const ArtifactCell = (props: Props): React.ReactElement => {
   brighterColor.s = 0.2;
   brighterColor.l = 0.8;
 
+  const textRef: React.RefObject<Text> = React.useRef(null);
+
   const handleValueChange = (toggled: boolean): void => {
     toggled ? onEnable(text) : onDisable(text);
   };
@@ -48,15 +51,23 @@ export const ArtifactCell = (props: Props): React.ReactElement => {
       <View style={styles.artifact}>
         <Hoverable>
           {isHovered => (
-            <TouchableOpacity accessibilityRole="button" onPress={handlePress} style={styles.name}>
-              <Text style={[isHovered && styles.hoveredText]}>{text}</Text>
-            </TouchableOpacity>
+            <View>
+              <TouchableOpacity accessibilityRole="button" onPress={handlePress} style={styles.name}>
+                <Text
+                  accessibilityLabel={text}
+                  ref={textRef}
+                  style={[styles.nameText, isHovered && styles.hoveredText]}
+                >
+                  {text}
+                </Text>
+              </TouchableOpacity>
+              {isHovered ? <Tooltip relativeTo={textRef} text={`Show "${text}" only`} /> : null}
+            </View>
           )}
         </Hoverable>
         <View style={styles.switch}>
           {
             // @ts-ignore
-
             <Switch
               activeThumbColor={color}
               activeTrackColor={brighterColor.toString()}
@@ -80,9 +91,20 @@ const styles = StyleSheet.create({
   name: {
     flexShrink: 1,
     flexGrow: 1,
+    maxWidth: '15vw',
     alignItems: 'flex-start',
     justifyContent: 'center',
     paddingEnd: Theme.Spacing.Xsmall
+  },
+  nameText: {
+    width: '100%',
+    whiteSpace: 'nowrap',
+    textAlign: 'left',
+    // @ts-ignore
+    display: 'block',
+    overflow: 'hidden',
+    // @ts-ignore
+    textOverflow: 'ellipsis'
   },
   switch: {
     paddingStart: Theme.Spacing.Xsmall


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Artifact names in the comparison table can end up really long, causing too much space to be used by the ArtifactCell column of the table.

# Solution

* Truncate to max 15vw with an ellipsis.
* Adds a tooltip that explains what happens when clicked, as well as the full name.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
