### PR TITLE
Emit TS declaration files

### DIFF
--- a/src/app/src/store/actions.ts
+++ b/src/app/src/store/actions.ts
@@ -4,6 +4,10 @@
 import Build from '@build-tracker/build';
 import ColorScale from '../modules/ColorScale';
 import {
+  // This must be imported because otherwise we get an error when `declaration` is enabled.
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Action,
   AddComparedRevision,
   AddSnack,
   ClearComparedRevision,

--- a/src/app/src/store/types.ts
+++ b/src/app/src/store/types.ts
@@ -39,7 +39,7 @@ export interface State {
   url: string;
 }
 
-interface Action<T, P, M = undefined> {
+export interface Action<T, P, M = undefined> {
   type: T;
   payload: P;
   meta?: M;

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -16,10 +16,8 @@
   "dependencies": {
     "@build-tracker/build": "^1.0.0-beta.4",
     "@build-tracker/formatting": "^1.0.0-beta.4",
+    "@build-tracker/types": "^1.0.0-beta.4",
     "markdown-table": "^1.1.2"
-  },
-  "devDependencies": {
-    "@build-tracker/types": "^1.0.0-beta.4"
   },
   "gitHead": "156788a6a199fc25e21adf354c106defd002afbf",
   "publishConfig": {

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -21,6 +21,7 @@
     "@build-tracker/build": "^1.0.0-beta.4",
     "@build-tracker/comparator": "^1.0.0-beta.4",
     "@build-tracker/formatting": "^1.0.0-beta.4",
+    "@build-tracker/types": "^1.0.0-beta.4",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "express-pino-logger": "^4.0.0",
@@ -31,7 +32,6 @@
   },
   "devDependencies": {
     "@build-tracker/fixtures": "^1.0.0-beta.3",
-    "@build-tracker/types": "^1.0.0-beta.4",
     "@types/body-parser": "^1.17.0",
     "@types/express": "^4.16.1",
     "@types/helmet": "^0.0.43",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
+    "declaration": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": false,
     "esModuleInterop": true,


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

This goes some of the way towards fixing https://github.com/paularmstrong/build-tracker/issues/105. Users will still need to manually import from the declaration file, as `types` still points towards the source file.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
