### PR TITLE
Pass budgets through to `Comparator`

### DIFF
--- a/src/server/src/api/insert.ts
+++ b/src/server/src/api/insert.ts
@@ -14,7 +14,7 @@ export const insertBuild = (
   onInserted: (comparator: Comparator) => Promise<void> = () => Promise.resolve()
 ): RequestHandler => (req: Request, res: Response): void => {
   const { artifacts, meta } = req.body;
-  const { artifacts: artifactConfig = {} } = config;
+  const { artifacts: artifactConfig = {}, budgets } = config;
   const build = new Build(meta, artifacts);
   queries.insert(build).then(() =>
     queries
@@ -37,6 +37,7 @@ export const insertBuild = (
           artifactBudgets: artifactConfig.budgets,
           artifactFilters: artifactConfig.filters,
           builds,
+          budgets,
           groups: artifactConfig.groups
         })
       }))


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Without this, the top level `budgets` config doesn't seem to do anything.

Note: I wasn't sure how to write a test for this one?

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
