### PR TITLE
[chore] upgrade yargs (fixes builds)

### DIFF
--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -20,7 +20,7 @@
     "glob": "^7.1.3",
     "gzip-size": "^5.0.0",
     "path-to-regexp": "3.0.0",
-    "yargs": "^13.2.1"
+    "yargs": "^15.0.0"
   },
   "devDependencies": {
     "@types/cosmiconfig": "^5.0.3",
@@ -28,7 +28,7 @@
     "@types/node": "^11.10.4",
     "@types/request": "^2.48.1",
     "@types/request-promise-native": "^1.0.15",
-    "@types/yargs": "^13.0.0",
+    "@types/yargs": "^15.0.0",
     "mock-spawn": "^0.2.6",
     "nock": "^10.0.6"
   },

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -27,7 +27,7 @@
     "glob": "^7.1.3",
     "helmet": "^3.15.1",
     "pino": "^5.11.1",
-    "yargs": "^13.2.1"
+    "yargs": "^15.0.0"
   },
   "devDependencies": {
     "@build-tracker/fixtures": "^1.0.0-beta.3",
@@ -36,7 +36,7 @@
     "@types/express": "^4.16.1",
     "@types/helmet": "^0.0.43",
     "@types/node": "^12.0.0",
-    "@types/yargs": "^13.0.0",
+    "@types/yargs": "^15.0.0",
     "node-mocks-http": "^1.7.3",
     "supertest": "^4.0.0",
     "ts-node": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,13 +2369,6 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
-"@types/yargs@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.0.tgz#d2acb3bec0047d8f648ebacdab6b928a900c42c4"
-  integrity sha512-hY0o+kcz9M6kH32NUeb6VURghqMuCVkiUx+8Btsqhj4Hhov/hVGUx9DmBJeIkzlp1uAQK4wngQBCjqWdUUkFyA==
-  dependencies:
-    "@types/yargs-parser" "*"
-
 "@types/yargs@^15.0.0":
   version "15.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.3.tgz#41453a0bc7ab393e995d1f5451455638edbd2baf"
@@ -14808,7 +14801,7 @@ yargs@12.0.5, yargs@^12.0.1:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@13.2.4, yargs@^13.2.1:
+yargs@13.2.4:
   version "13.2.4"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
   integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Jest upgrade caused builds to fail because of multiple `@types/yargs` versions. 

# Solution

Upgrade yargs to latest (matches jest). Not sure how to make a better long-term solution in which these can deviate

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
