### PR TITLE
[server] default artifactConfig parts individually (#104)

### DIFF
--- a/src/server/src/__tests__/server.test.ts
+++ b/src/server/src/__tests__/server.test.ts
@@ -45,7 +45,7 @@ describe('server', () => {
           });
       });
 
-      test('defaults artifactConfig to empty object', () => {
+      test('defaults artifactConfig if unset', () => {
         const app = express();
         const config = {};
         app.use(props(config, 'https://build-tracker.local'));
@@ -54,7 +54,22 @@ describe('server', () => {
           .get('/')
           .then(res => {
             expect(res.body.props).toMatchObject({
-              artifactConfig: {},
+              artifactConfig: { budgets: {}, filters: [], groups: [] },
+              url: 'https://build-tracker.local'
+            });
+          });
+      });
+
+      test('defaults individual keys of artifactConfig', () => {
+        const app = express();
+        const config = { artifacts: { filters: [/foo/] } };
+        app.use(props(config, 'https://build-tracker.local'));
+        app.get('/', localsToBody);
+        return request(app)
+          .get('/')
+          .then(res => {
+            expect(res.body.props).toMatchObject({
+              artifactConfig: { budgets: {}, filters: [/foo/], groups: [] },
               url: 'https://build-tracker.local'
             });
           });

--- a/src/server/src/server.ts
+++ b/src/server/src/server.ts
@@ -39,7 +39,7 @@ export const props = (config: AppConfig, url: string): RequestHandler => (
 ): void => {
   res.locals.props = {
     url,
-    artifactConfig: config.artifacts || {},
+    artifactConfig: Object.assign({}, { budgets: {}, filters: [], groups: [] }, config.artifacts || {}),
     hideAttribution: !!config.hideAttribution,
     name: config.name || 'Build Tracker'
   };


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

If an `artifacts` config is not provided, or the optional parts are missing, the application can silently fail.

# Solution

Default all keys and assign the provided config over the default.

Fixes #104 

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
