### PR TITLE
Correct CI example

### DIFF
--- a/docs/docs/guides/ci.md
+++ b/docs/docs/guides/ci.md
@@ -24,6 +24,8 @@ const Comparator = require('@build-tracker/comparator').default;
 
 const applicationUrl = 'https://my-application-url.local';
 
+const last = xs => xs[xs.length - 1];
+
 module.exports = {
   applicationUrl,
   // ... other config options
@@ -32,7 +34,7 @@ module.exports = {
     // Reconstruct a comparator from the serialized data
     const comparator = Comparator.deserialize(comparatorData);
 
-    const build = comparator.builds[0];
+    const build = last(comparator.builds);
 
     const table = comparator.toMarkdown({ artifactFilter });
     const revisions = `${build.getMetaValue('parentRevision')}/${build.getMetaValue('revision')}`;


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Forgot to update this example alongside my fixes in https://github.com/paularmstrong/build-tracker/pull/131. The _current_ build will now be the last item in the array, not the first.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
