### PR TITLE
Remove redundant logging

### DIFF
--- a/src/cli/src/commands/__tests__/upload-build.test.ts
+++ b/src/cli/src/commands/__tests__/upload-build.test.ts
@@ -39,7 +39,6 @@ describe('upload-build', () => {
   describe('handler', () => {
     test('uploads the current build', async () => {
       jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
-      const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
       const configValues = require(config);
 
       nock(`${configValues.applicationUrl}/`)
@@ -47,7 +46,6 @@ describe('upload-build', () => {
         .reply(200, { success: 'yep' });
 
       await expect(Command.handler({ config, out: true, 'skip-dirty-check': true })).resolves.toBeUndefined();
-      expect(writeSpy).toHaveBeenCalledWith('{"success":"yep"}');
     });
 
     test('invokes `onCompare`', async () => {
@@ -80,7 +78,6 @@ describe('upload-build', () => {
 
     test('uploads the current build over http', async () => {
       jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
-      const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
       const configValues = require(httpConfig);
 
       nock(`${configValues.applicationUrl}/`)
@@ -90,7 +87,6 @@ describe('upload-build', () => {
       await expect(
         Command.handler({ config: httpConfig, out: true, 'skip-dirty-check': true })
       ).resolves.toBeUndefined();
-      expect(writeSpy).toHaveBeenCalledWith('{"success":"yep"}');
     });
 
     test('sends the BT_API_AUTH_TOKEN', async () => {
@@ -98,7 +94,6 @@ describe('upload-build', () => {
       process.env.BT_API_AUTH_TOKEN = 'test-token';
 
       jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
-      const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementationOnce(() => true);
       const configValues = require(httpConfig);
 
       nock(`${configValues.applicationUrl}/`)
@@ -109,13 +104,11 @@ describe('upload-build', () => {
       await expect(
         Command.handler({ config: httpConfig, out: true, 'skip-dirty-check': true })
       ).resolves.toBeUndefined();
-      expect(writeSpy).toHaveBeenCalledWith('{"success":"yep"}');
       process.env.BT_API_AUTH_TOKEN = prevToken;
     });
 
     test('rejects on error response', async () => {
       jest.spyOn(CreateBuild, 'handler').mockImplementation(() => Promise.resolve(postData));
-      const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementationOnce(() => true);
       const configValues = require(config);
 
       const responseError = new Error('some error');
@@ -125,7 +118,6 @@ describe('upload-build', () => {
         .replyWithError(responseError);
 
       await expect(Command.handler({ config, out: true, 'skip-dirty-check': true })).rejects.toBe(responseError);
-      expect(writeSpy).toHaveBeenCalledWith(responseError.toString());
     });
   });
 });

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -77,7 +77,6 @@ export const handler = async (args: Args): Promise<void> => {
 
       res.on('data', data => {
         output.push(data);
-        process.stdout.write(data);
       });
 
       res.on('end', () => {
@@ -96,7 +95,6 @@ export const handler = async (args: Args): Promise<void> => {
     });
 
     req.on('error', error => {
-      process.stderr.write(error.toString());
       reject(error);
     });
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

We resolve/reject the promise, passing all necessary information, so we don't need to log this.

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
