### PR TITLE
[app][server] ensure budgets passed to comparator

### DIFF
--- a/src/app/src/store/__tests__/reducer.test.ts
+++ b/src/app/src/store/__tests__/reducer.test.ts
@@ -12,6 +12,7 @@ const initialState: State = Object.freeze({
   activeArtifacts: {},
   activeComparator: null,
   artifactConfig: {},
+  budgets: [],
   builds: [],
   colorScale: Object.keys(ColorScale)[0],
   comparator: new Comparator({ builds: [] }),

--- a/src/app/src/store/index.ts
+++ b/src/app/src/store/index.ts
@@ -13,6 +13,7 @@ export default function makeStore(initialState: Partial<State> = {}): Store<Stat
     activeArtifacts: {},
     activeComparator: null,
     artifactConfig: {},
+    budgets: [],
     builds: [],
     colorScale: Object.keys(ColorScale)[0],
     comparator: new Comparator({ builds: [] }),

--- a/src/app/src/store/types.ts
+++ b/src/app/src/store/types.ts
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import { AppConfig } from '@build-tracker/types';
 import Build from '@build-tracker/build';
 import ColorScale from '../modules/ColorScale';
 import Comparator from '@build-tracker/comparator';
+import { AppConfig, Budget } from '@build-tracker/types';
 
 export enum FetchState {
   NONE,
@@ -22,6 +22,7 @@ export interface State {
   activeArtifacts: { [key: string]: boolean };
   activeComparator: Comparator;
   artifactConfig: AppConfig['artifacts'];
+  budgets: Array<Budget>;
   builds: Array<Build>;
   colorScale: keyof typeof ColorScale;
   comparator: Comparator;

--- a/src/server/src/server.ts
+++ b/src/server/src/server.ts
@@ -40,6 +40,7 @@ export const props = (config: AppConfig, url: string): RequestHandler => (
   res.locals.props = {
     url,
     artifactConfig: Object.assign({}, { budgets: {}, filters: [], groups: [] }, config.artifacts || {}),
+    budgets: config.budgets || [],
     hideAttribution: !!config.hideAttribution,
     name: config.name || 'Build Tracker',
     defaultSizeKey: config.defaultSizeKey


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

The sum budgets (main key `budgets` in server config) are not passed into the app

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Add them. Ensure they are passed into the `comparator` and `activeComparator`

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
