### PR TITLE
[formatting] reduce zeroes in %-value formatting

### DIFF
--- a/src/formatting/src/__tests__/index.test.ts
+++ b/src/formatting/src/__tests__/index.test.ts
@@ -104,14 +104,14 @@ describe('formatBudgetResult', () => {
             sizeKey: 'stat',
             passing: false,
             expected: 0.1,
-            actual: 0.2,
+            actual: 0.22345,
             type: BudgetType.PERCENT_DELTA,
             level: BudgetLevel.ERROR
           },
           'tacos'
         )
       ).toEqual(
-        'Error: `tacos` failed the stat budget percent change limit. Expected no increase by no more than 10.000%, but increased by 20.000%'
+        'Error: `tacos` failed the stat budget percent change limit. Expected to not increase by more than 10%, but increased by 22.4%'
       );
     });
   });
@@ -175,14 +175,14 @@ describe('formatBudgetResult', () => {
             sizeKey: 'stat',
             passing: false,
             expected: 0.1,
-            actual: 0.2,
+            actual: 1.6354908725,
             type: BudgetType.PERCENT_DELTA,
             level: BudgetLevel.WARN
           },
           'tacos'
         )
       ).toEqual(
-        'Warning: `tacos` failed the stat budget percent change limit. Expected no increase by no more than 10.000%, but increased by 20.000%'
+        'Warning: `tacos` failed the stat budget percent change limit. Expected to not increase by more than 10%, but increased by 163.6%'
       );
     });
   });

--- a/src/formatting/src/index.ts
+++ b/src/formatting/src/index.ts
@@ -29,7 +29,8 @@ export function formatSha(sha: string): string {
 }
 
 function formatPercent(value: number): string {
-  return `${(value * 100).toFixed(3)}%`;
+  const val = Math.ceil(value * 1000) / 10;
+  return `${val}%`;
 }
 
 const levelToString = {
@@ -55,7 +56,7 @@ export function formatBudgetResult(budgetResult: BudgetResult, itemName: string,
     case BudgetType.DELTA:
       return `${prefix} failed the ${sizeKey} budget delta limit. Expected to increase no more than ${expectedFormatted}, but increased by ${actualFormatted}`;
     case BudgetType.PERCENT_DELTA:
-      return `${prefix} failed the ${sizeKey} budget percent change limit. Expected no increase by no more than ${expectedFormatted}, but increased by ${actualFormatted}`;
+      return `${prefix} failed the ${sizeKey} budget percent change limit. Expected to not increase by more than ${expectedFormatted}, but increased by ${actualFormatted}`;
     case BudgetType.SIZE:
       return `${prefix} failed the ${sizeKey} budget size limit of ${expectedFormatted} by ${diffFormatted}`;
   }


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Reading percent deltas like `10.000%` is silly

# Solution

Since this is for visual inspection and actual values tend to be more important if you want to run real reports, simply do a ceiling at 1 decimal place.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
