### PR TITLE
[app] copy link limits to selected revisions

### DIFF
--- a/src/app/src/views/AppBar.tsx
+++ b/src/app/src/views/AppBar.tsx
@@ -72,6 +72,9 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
   }, [activeComparator, artifactFilter, dispatch, sizeKey]);
 
   const handleCopyLink = React.useCallback((): void => {
+    const url = new URL(window.location.href);
+    url.pathname = `/builds/${comparedRevisions.join('/')}`;
+
     const params = new URLSearchParams();
     params.append('sizeKey', sizeKey);
     params.append('disabledArtifactsVisible', `${disabledArtifactsVisible}`);
@@ -87,12 +90,11 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
       });
     }
 
-    const newUrl = new URL(window.location.href);
-    newUrl.search = params.toString();
-    Clipboard.setString(newUrl.toString());
+    url.search = params.toString();
+    Clipboard.setString(url.toString());
     dispatch(addSnack('Copied link to clipboard'));
     appBarRef.current.dismissOverflow();
-  }, [sizeKey, disabledArtifactsVisible, graphType, comparedRevisions, activeArtifacts, dispatch]);
+  }, [activeArtifacts, comparedRevisions, disabledArtifactsVisible, dispatch, graphType, sizeKey]);
 
   const handleCopySummary = React.useCallback((): void => {
     Clipboard.setString(`${activeComparator.toSummary().join(' \n')}`);
@@ -112,6 +114,7 @@ const AppBarView = (props: { drawerRef: React.RefObject<DrawerHandles> }): React
             <MenuItem key="summary" icon={ListBulletedIcon} label="Copy summary" onPress={handleCopySummary} />
             <MenuItem key="md" icon={TableIcon} label="Copy as markdown" onPress={handleCopyAsMarkdown} />
             <MenuItem key="csv" icon={DocumentIcon} label="Copy as CSV" onPress={handleCopyAsCsv} />
+            <Divider />
             <MenuItem key="link" icon={LinkIcon} label="Copy link" onPress={handleCopyLink} />
           </>
         ) : null

--- a/src/app/src/views/__tests__/AppBar.test.tsx
+++ b/src/app/src/views/__tests__/AppBar.test.tsx
@@ -177,7 +177,7 @@ describe('AppBarView', () => {
       fireEvent.press(getByProps({ label: 'Copy link' }));
 
       expect(clipboardSpy).toHaveBeenCalledWith(
-        'https://build-tracker.local/?sizeKey=gzip&disabledArtifactsVisible=true&graphType=AREA&comparedRevisions=22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04&comparedRevisions=01141f29743fb2bdd7e176cf919fc964025cea5a&activeArtifacts=main&activeArtifacts=shared'
+        'https://build-tracker.local/builds/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04/01141f29743fb2bdd7e176cf919fc964025cea5a?sizeKey=gzip&disabledArtifactsVisible=true&graphType=AREA&comparedRevisions=22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04&comparedRevisions=01141f29743fb2bdd7e176cf919fc964025cea5a&activeArtifacts=main&activeArtifacts=shared'
       );
     });
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

When I share links with people, I expect the graph to be limited to the selected revisions only. Currently, it relies on the query that is run, which may be invalid long-term. Example: get 10 most recent builds and share a link to the first two–as soon as two new builds are made, this URL will not work.

# Solution

Always give a URL with a path directly to the builds.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
