### PR TITLE
[app] ensure all meta items in BuildInfo are linked if URL is available

### DIFF
--- a/src/app/src/components/BuildInfo.tsx
+++ b/src/app/src/components/BuildInfo.tsx
@@ -70,14 +70,13 @@ const BuildInfo = (props: Props): React.ReactElement => {
             .filter(metaKey => metaKey !== 'revision' && metaKey !== 'timestamp')
             .map((metaKey: 'revision' | 'parentRevision' | 'branch') => {
               const value = build.getMetaValue(metaKey);
+              const url = build.getMetaUrl(metaKey);
               return (
                 <Tr key={metaKey}>
                   <Th>
                     <Text>{titleCase(metaKey)}</Text>
                   </Th>
-                  <Td style={styles.infoCell}>
-                    <Text>{value}</Text>
-                  </Td>
+                  <Td style={styles.infoCell}>{url ? <TextLink href={url} text={value} /> : <Text>{value}</Text>}</Td>
                 </Tr>
               );
             })}

--- a/src/app/src/components/__tests__/BuildInfo.test.tsx
+++ b/src/app/src/components/__tests__/BuildInfo.test.tsx
@@ -49,6 +49,30 @@ describe('BuildInfo', () => {
     });
   });
 
+  test('renders a text link for other keys that have a URL', () => {
+    const buildA = new Build(
+      {
+        branch: 'master',
+        revision: '123456',
+        parentRevision: {
+          value: 'abcdef',
+          url: 'https://github.com/paularmstrong/build-tracker/commit/abcdef'
+        },
+        timestamp: 123
+      },
+      []
+    );
+    const { getByType } = render(
+      <Provider store={mockStore({ comparator: new Comparator({ builds: [buildA] }) })}>
+        <BuildInfo focusedRevision="123456" />
+      </Provider>
+    );
+    expect(getByType(TextLink).props).toMatchObject({
+      href: 'https://github.com/paularmstrong/build-tracker/commit/abcdef',
+      text: 'abcdef'
+    });
+  });
+
   test('removes the build focus on button press', () => {
     const removeComparedRevisionSpy = jest.spyOn(Actions, 'removeComparedRevision');
     const { getByProps } = render(

--- a/src/cli/src/commands/__tests__/create-build.test.ts
+++ b/src/cli/src/commands/__tests__/create-build.test.ts
@@ -137,13 +137,16 @@ describe('create-build', () => {
       });
     });
 
-    test('returns a revision url if buildUrlFormat is provided', async () => {
+    test('returns a revision and parentRevision url if buildUrlFormat is provided', async () => {
       getBranchSpy.mockReturnValue(Promise.resolve('tacobranch'));
 
       await expect(
         Command.handler({ config: configWithFormatUrl, out: false, 'skip-dirty-check': true })
       ).resolves.toMatchObject({
-        meta: { revision: { url: 'https://github.com/paularmstrong/build-tracker/commit/abcdefg', value: 'abcdefg' } }
+        meta: {
+          revision: { url: 'https://github.com/paularmstrong/build-tracker/commit/abcdefg', value: 'abcdefg' },
+          parentRevision: { url: 'https://github.com/paularmstrong/build-tracker/commit/1234567', value: '1234567' }
+        }
       });
     });
   });

--- a/src/cli/src/commands/create-build.ts
+++ b/src/cli/src/commands/create-build.ts
@@ -82,7 +82,7 @@ export const handler = async (args: Args): Promise<{}> => {
   const defaultBranch = await Git.getDefaultBranch(config.cwd);
   const branch = args.branch ? args.branch : await Git.getBranch(config.cwd);
   let revision: BuildMetaItem = await Git.getCurrentRevision(config.cwd);
-  const parentRevision =
+  let parentRevision: BuildMetaItem =
     args['parent-revision'] ||
     (branch !== defaultBranch
       ? await Git.getMergeBase(defaultBranch, config.cwd)
@@ -91,10 +91,16 @@ export const handler = async (args: Args): Promise<{}> => {
 
   if (config.buildUrlFormat) {
     const toPath = pathToRegexp.compile(config.buildUrlFormat);
-    const url = toPath({ revision });
+    const revisionUrl = toPath({ revision });
     revision = {
       value: revision,
-      url
+      url: revisionUrl
+    };
+
+    const parentRevisionUrl = toPath({ revision: parentRevision });
+    parentRevision = {
+      value: parentRevision,
+      url: parentRevisionUrl
     };
   }
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

All meta values on builds can be linkable, but this isn't reflected in the `BuildInfo` panel.

# Solution

Ensure they're all linked if a URL is available.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
