### PR TITLE
[comparator] sort builds on comparator create

### DIFF
--- a/src/comparator/src/__tests__/index.test.ts
+++ b/src/comparator/src/__tests__/index.test.ts
@@ -55,6 +55,22 @@ describe('BuildComparator', () => {
     });
   });
 
+  describe('builds', () => {
+    test('sorts by timestamp, then parentRevision', () => {
+      const build3 = new Build(
+        { branch: 'master', revision: 'abcdef', parentRevision: build1.getMetaValue('revision'), timestamp: 1234566 },
+        [
+          { name: 'burritos', hash: 'abc', sizes: { stat: 456, gzip: 90 } },
+          { name: 'tacos', hash: 'abc', sizes: { stat: 123, gzip: 45 } }
+        ]
+      );
+      const comparator = new BuildComparator({ builds: [build2, build3, build1] });
+      expect(comparator.builds[0]).toBe(build1);
+      expect(comparator.builds[1]).toBe(build3);
+      expect(comparator.builds[2]).toBe(build2);
+    });
+  });
+
   describe('artifactFilters', () => {
     let comparator;
     beforeEach(() => {

--- a/src/comparator/src/index.ts
+++ b/src/comparator/src/index.ts
@@ -148,7 +148,25 @@ export default class BuildComparator {
   private _matrixArtifacts: ComparisonMatrix['artifacts'];
 
   public constructor({ artifactBudgets, artifactFilters, budgets, builds, groups }: ComparatorOptions) {
-    this.builds = builds;
+    this.builds = builds
+      .sort((buildA, buildB) => {
+        const diff = buildA.timestamp.valueOf() - buildB.timestamp.valueOf();
+        if (diff > 0) {
+          return 1;
+        } else if (diff < 0) {
+          return -1;
+        }
+        return 0;
+      })
+      .sort((buildA, buildB) => {
+        if (buildA.getMetaValue('parentRevision') === buildB.getMetaValue('revision')) {
+          return 1;
+        }
+        if (buildB.getMetaValue('revision') === buildA.getMetaValue('parentRevision')) {
+          return -1;
+        }
+        return 0;
+      });
     this._artifactFilters = artifactFilters || [];
     this._artifactBudgets = artifactBudgets || emptyObject;
     this._groups = [{ name: 'All', artifactNames: this.artifactNames, budgets }, ...(groups || [])].filter(Boolean);


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Sometimes in the UI, my builds appear out of order when I link directly to a comparison, because the SHAs get alpha-numeric sorted.

# Solution

The comparator can automatically sort the builds.
* First, by timestamp
* Second, by checking revision/parentRevision and determining if one should come directly after the other

Related: 
* 81d47870a40477de4bc42d63df782b4a8f74689b
* #130 
* #131 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
