### PR TITLE
Ignore directions when running glob

### DIFF
--- a/src/cli/src/commands/__tests__/create-build.test.ts
+++ b/src/cli/src/commands/__tests__/create-build.test.ts
@@ -125,12 +125,12 @@ describe('create-build', () => {
             }
           },
           {
-            hash: 'd41d8cd98f00b204e9800998ecf8427e',
-            name: '../../fakedist/test-folder/test',
+            hash: '415dec15fc798bb79f499aeff00258fb',
+            name: '../../fakedist/test-folder/test-no-extension',
             sizes: {
               brotli: 49,
-              gzip: 20,
-              stat: 0
+              gzip: 54,
+              stat: 34
             }
           },
           {

--- a/src/cli/src/commands/__tests__/create-build.test.ts
+++ b/src/cli/src/commands/__tests__/create-build.test.ts
@@ -125,6 +125,15 @@ describe('create-build', () => {
             }
           },
           {
+            hash: 'd41d8cd98f00b204e9800998ecf8427e',
+            name: '../../fakedist/test-folder/test',
+            sizes: {
+              brotli: 49,
+              gzip: 20,
+              stat: 0
+            }
+          },
+          {
             hash: 'fc4bcd175441f89862f9d81e37599416',
             name: '../../fakedist/vendor.js',
             sizes: {

--- a/src/cli/src/commands/__tests__/stat-artifacts.test.ts
+++ b/src/cli/src/commands/__tests__/stat-artifacts.test.ts
@@ -36,6 +36,12 @@ describe('stat-artifacts command', () => {
               hash: '631a500f31d7602a386b4f858338dd6f'
               // NOTE: if brotli is availalbe, it will appear here
             }),
+            '../../fakedist/test-folder/test': expect.objectContaining({
+              brotli: 1,
+              gzip: 20,
+              hash: 'd41d8cd98f00b204e9800998ecf8427e',
+              stat: 0
+            }),
             '../../fakedist/vendor.js': expect.objectContaining({
               stat: 82,
               gzip: 82,

--- a/src/cli/src/commands/__tests__/stat-artifacts.test.ts
+++ b/src/cli/src/commands/__tests__/stat-artifacts.test.ts
@@ -36,11 +36,11 @@ describe('stat-artifacts command', () => {
               hash: '631a500f31d7602a386b4f858338dd6f'
               // NOTE: if brotli is availalbe, it will appear here
             }),
-            '../../fakedist/test-folder/test': expect.objectContaining({
-              brotli: 1,
-              gzip: 20,
-              hash: 'd41d8cd98f00b204e9800998ecf8427e',
-              stat: 0
+            '../../fakedist/test-folder/test-no-extension': expect.objectContaining({
+              brotli: 29,
+              gzip: 54,
+              hash: '415dec15fc798bb79f499aeff00258fb',
+              stat: 34
             }),
             '../../fakedist/vendor.js': expect.objectContaining({
               stat: 82,

--- a/src/cli/src/commands/stat-artifacts.ts
+++ b/src/cli/src/commands/stat-artifacts.ts
@@ -51,7 +51,7 @@ export const handler = async (args: Args): Promise<{ artifacts: Map<string, Stat
 
   const artifacts = new Map();
   artifactGlobs.forEach(fileGlob => {
-    glob.sync(path.resolve(cwd, fileGlob)).forEach(filePath => {
+    glob.sync(path.resolve(cwd, fileGlob), { nodir: true }).forEach(filePath => {
       const sizes = readfile(filePath, getFilenameHash);
       artifacts.set(nameMapper(path.relative(baseDir, filePath).replace(`.${sizes.hash}`, '')), sizes);
     });

--- a/src/fixtures/cli-configs/fakedist/test-folder/test-no-extension
+++ b/src/fixtures/cli-configs/fakedist/test-folder/test-no-extension
@@ -1,0 +1,1 @@
+this file intentionally left blank

--- a/src/fixtures/cli-configs/rc/.build-trackerrc.js
+++ b/src/fixtures/cli-configs/rc/.build-trackerrc.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   applicationUrl: 'https://build-tracker.local',
-  artifacts: ['../fakedist/*.js'],
+  artifacts: ['../fakedist/**/*'],
   baseDir: path.resolve(__dirname, 'fakedist'),
   cwd: __dirname,
   onCompare: data => Promise.resolve()


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

We tried to use the glob `**/*` to include all artifacts, regardless of file extension, however we were getting an exception:

```
    EISDIR: illegal operation on a directory, read
```

# Solution

<!--
When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
