### PR TITLE
Unify emoji

### DIFF
--- a/docs/docs/packages/comparator.md
+++ b/docs/docs/packages/comparator.md
@@ -86,17 +86,19 @@ Returns an array Markdown-formatted summaries of the overall comparison and any 
 [
   '⚠️: `Group \\"All\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB',
   '⚠️: `Group \\"warning\\"` failed the gzip budget size limit of 0 KiB by 0.12 KiB',
-  '🚨: `Group \\"error\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB'
+  '🚨: `Group \\"error\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB',
+  '#️⃣: `burritos` hash changed without any file size change'
 ];
 ```
 
 If `useEmoji` is set to `false`, emoji will be replaced with words:
 
-| Emoji        | Word    |
-| ------------ | ------- |
-| ✅ (U+2705)  | Success |
-| ⚠️ (U+26A0)  | Warning |
-| 🚨 (U+1F6A9) | Error   |
+| Emoji            | Word    |
+| ---------------- | ------- |
+| ✅ (U+2705)      | Success |
+| ⚠️ (U+26A0)      | Warning |
+| 🚨 (U+1F6A9)     | Error   |
+| #️⃣ (U+0023-20E3) | Hash    |
 
 ## Types
 

--- a/docs/docs/packages/comparator.md
+++ b/docs/docs/packages/comparator.md
@@ -86,7 +86,7 @@ Returns an array Markdown-formatted summaries of the overall comparison and any 
 [
   '⚠️: `Group \\"All\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB',
   '⚠️: `Group \\"warning\\"` failed the gzip budget size limit of 0 KiB by 0.12 KiB',
-  '🚫: `Group \\"error\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB'
+  '🚨: `Group \\"error\\"` failed the gzip budget size limit of 0 KiB by 0.16 KiB'
 ];
 ```
 
@@ -96,7 +96,7 @@ If `useEmoji` is set to `false`, emoji will be replaced with words:
 | ------------ | ------- |
 | ✅ (U+2705)  | Success |
 | ⚠️ (U+26A0)  | Warning |
-| 🚫 (U+1F6AB) | Error   |
+| 🚨 (U+1F6A9) | Error   |
 
 ## Types
 

--- a/src/app/src/components/ComparisonTable/__tests__/DeltaCell.test.tsx
+++ b/src/app/src/components/ComparisonTable/__tests__/DeltaCell.test.tsx
@@ -4,6 +4,7 @@
 import { CellType } from '@build-tracker/comparator';
 import { DeltaCell } from '../DeltaCell';
 import ErrorIcon from '../../../icons/Error';
+import HashIcon from '../../../icons/Hash';
 import React from 'react';
 import { Td } from '../../Table';
 import WarningIcon from '../../../icons/Warning';
@@ -65,7 +66,7 @@ describe('DeltaCell', () => {
         />
       );
 
-      expect(getByType(Td).props.accessibilityLabel).toEqual('-134 bytes (-50.000%)');
+      expect(getByType(Td).props.accessibilityLabel).toEqual('"tacos" changed by -134 bytes (-50.000%)');
     });
 
     test('shows a warning label if no change, but hash changed', () => {
@@ -83,8 +84,8 @@ describe('DeltaCell', () => {
           sizeKey="stat"
         />
       );
-      expect(queryAllByType(WarningIcon)).toHaveLength(1);
-      expect(getByType(Td).props.accessibilityLabel).toEqual('Unexpected hash change! 0 bytes (0.000%)');
+      expect(queryAllByType(HashIcon)).toHaveLength(1);
+      expect(getByType(Td).props.accessibilityLabel).toEqual('Hash: `tacos` hash changed without any file size change');
     });
 
     test('shows a warning icon if warning budget fails', () => {

--- a/src/app/src/icons/Hash.tsx
+++ b/src/app/src/icons/Hash.tsx
@@ -1,0 +1,29 @@
+/**
+ * Material design redistributed from https://github.com/Templarian/MaterialDesign-JS
+ *
+ * SVG contents redistributed under MIT License
+ * https://github.com/Templarian/MaterialDesign-JS/blob/master/LICENSE
+ * Copyright 2018 Austin Andrews
+ */
+import React from 'react';
+import styles from './styles';
+import { StyleProp, TextStyle, unstable_createElement, ViewProps } from 'react-native';
+
+interface Props extends ViewProps {
+  style?: StyleProp<TextStyle>;
+}
+
+const Error = (props: Props): React.ReactElement<Props> =>
+  unstable_createElement(
+    'svg',
+    {
+      ...props,
+      style: [styles.root, props.style],
+      viewBox: '0 0 24 24'
+    },
+    <path d="M3,5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5C3.89,21 3,20.1 3,19V5M7,18H9L9.35,16H13.35L13,18H15L15.35,16H17.35L17.71,14H15.71L16.41,10H18.41L18.76,8H16.76L17.12,6H15.12L14.76,8H10.76L11.12,6H9.12L8.76,8H6.76L6.41,10H8.41L7.71,14H5.71L5.35,16H7.35L7,18M10.41,10H14.41L13.71,14H9.71L10.41,10Z" />
+  );
+
+Error.metadata = { height: 24, width: 24 };
+
+export default Error;

--- a/src/comparator/src/__tests__/index.test.ts
+++ b/src/comparator/src/__tests__/index.test.ts
@@ -603,7 +603,7 @@ describe('BuildComparator', () => {
       expect(comparator.toSummary().join('\n')).toMatchInlineSnapshot(`
         "⚠️: \`churros\` failed the gzip budget size limit of 0.1 KiB by 0.02 KiB
         ⚠️: \`tacos\` failed the gzip budget size limit of 0 KiB by 0.04 KiB
-        🚫: \`tacos\` failed the gzip budget size limit of 0.03 KiB by 0.01 KiB"
+        🚨: \`tacos\` failed the gzip budget size limit of 0.03 KiB by 0.01 KiB"
       `);
     });
 
@@ -627,7 +627,7 @@ describe('BuildComparator', () => {
       expect(comparator.toSummary().join('\n')).toMatchInlineSnapshot(`
         "⚠️: \`Group \\"All\\"\` failed the gzip budget size limit of 0 KiB by 0.16 KiB
         ⚠️: \`Group \\"warning\\"\` failed the gzip budget size limit of 0 KiB by 0.12 KiB
-        🚫: \`Group \\"error\\"\` failed the gzip budget size limit of 0 KiB by 0.16 KiB"
+        🚨: \`Group \\"error\\"\` failed the gzip budget size limit of 0 KiB by 0.16 KiB"
       `);
     });
 

--- a/src/comparator/src/__tests__/index.test.ts
+++ b/src/comparator/src/__tests__/index.test.ts
@@ -36,6 +36,14 @@ const build2 = new Build(
     { name: 'churros', hash: 'def', sizes: { stat: 469, gzip: 120 } }
   ]
 );
+// Alternative to build2 with burritos
+const build2b = new Build(
+  { branch: 'master', revision: '8901234abcdef', parentRevision: 'abcdef', timestamp: 8901234 },
+  [
+    { name: 'tacos', hash: 'abc', sizes: { stat: 123, gzip: 45 } },
+    { name: 'burritos', hash: 'def', sizes: { stat: 456, gzip: 90 } }
+  ]
+);
 
 const artifactFilters = [/burritos/, /churros/];
 
@@ -368,9 +376,9 @@ describe('BuildComparator', () => {
     test('handles 0 artifacts', () => {
       const comparator = new BuildComparator({ builds: [build1, build1b] });
       expect(comparator.toMarkdown({ artifactFilter: () => false })).toMatchInlineSnapshot(`
-      "|     |  1234567 |  1234567 |           Δ1 |
-      | :-- | -------: | -------: | -----------: |
-      | All | 0.13 KiB | 0.13 KiB | 0 KiB (0.0%) |"
+        "|     |  1234567 |  1234567 |           Δ1 |
+        | :-- | -------: | -------: | -----------: |
+        | All | 0.13 KiB | 0.13 KiB | 0 KiB (0.0%) |"
       `);
     });
 
@@ -489,6 +497,19 @@ describe('BuildComparator', () => {
       `);
     });
 
+    test('includes hash emoji for unexpected hash changes', () => {
+      const comparator = new BuildComparator({
+        builds: [build1, build2b]
+      });
+      expect(comparator.toMarkdown()).toMatchInlineSnapshot(`
+"|          |  1234567 |  8901234 |               Δ1 |
+| :------- | -------: | -------: | ---------------: |
+| All      | 0.13 KiB | 0.13 KiB | #️⃣ 0 KiB (0.0%) |
+| burritos | 0.09 KiB | 0.09 KiB | #️⃣ 0 KiB (0.0%) |
+| tacos    | 0.04 KiB | 0.04 KiB |     0 KiB (0.0%) |"
+`);
+    });
+
     test('includes emoji for failing group budgets', () => {
       const comparator = new BuildComparator({
         builds: [build1, build2],
@@ -562,10 +583,10 @@ describe('BuildComparator', () => {
     test('does not include filtered artifacts', () => {
       const comparator = new BuildComparator({ builds: [build1, build2], artifactFilters });
       expect(comparator.toCsv()).toMatchInlineSnapshot(`
-        ",1234567,8901234,Δ1
-        All,0.04 KiB,0.04 KiB,0 KiB (-4.4%)
-        tacos,0.04 KiB,0.04 KiB,0 KiB (-4.4%)"
-      `);
+",1234567,8901234,Δ1
+All,0.04 KiB,0.04 KiB,0 KiB (-4.4%)
+tacos,0.04 KiB,0.04 KiB,0 KiB (-4.4%)"
+`);
     });
 
     test('accepts formatting and filtering options', () => {
@@ -591,7 +612,7 @@ describe('BuildComparator', () => {
   describe('summary', () => {
     test('returns a list of errors and warnings for artifacts', () => {
       const comparator = new BuildComparator({
-        builds: [build1, build2],
+        builds: [build1, build2b],
         artifactBudgets: {
           churros: [{ level: BudgetLevel.WARN, type: BudgetType.SIZE, maximum: 100, sizeKey: 'gzip' }],
           tacos: [
@@ -601,10 +622,10 @@ describe('BuildComparator', () => {
         }
       });
       expect(comparator.toSummary().join('\n')).toMatchInlineSnapshot(`
-        "⚠️: \`churros\` failed the gzip budget size limit of 0.1 KiB by 0.02 KiB
-        ⚠️: \`tacos\` failed the gzip budget size limit of 0 KiB by 0.04 KiB
-        🚨: \`tacos\` failed the gzip budget size limit of 0.03 KiB by 0.01 KiB"
-      `);
+"#️⃣: \`burritos\` hash changed without any file size change
+⚠️: \`tacos\` failed the gzip budget size limit of 0 KiB by 0.04 KiB
+🚨: \`tacos\` failed the gzip budget size limit of 0.03 KiB by 0.01 KiB"
+`);
     });
 
     test('returns a list of errors and warnings for groups', () => {

--- a/src/formatting/src/__tests__/index.test.ts
+++ b/src/formatting/src/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe('formatBudgetResult', () => {
           'tacos',
           true
         )
-      ).toEqual('🚫: `tacos` failed the stat budget size limit of 2 KiB by 2 KiB');
+      ).toEqual('🚨: `tacos` failed the stat budget size limit of 2 KiB by 2 KiB');
     });
 
     test('size', () => {

--- a/src/formatting/src/index.ts
+++ b/src/formatting/src/index.ts
@@ -40,7 +40,7 @@ const levelToString = {
 
 const levelToEmoji = {
   [BudgetLevel.WARN]: '⚠️',
-  [BudgetLevel.ERROR]: '🚫'
+  [BudgetLevel.ERROR]: '🚨'
 };
 
 export function formatBudgetResult(budgetResult: BudgetResult, itemName: string, useEmoji = false): string {

--- a/src/formatting/src/index.ts
+++ b/src/formatting/src/index.ts
@@ -35,22 +35,28 @@ function formatPercent(value: number): string {
 
 const levelToString = {
   [BudgetLevel.WARN]: 'Warning',
-  [BudgetLevel.ERROR]: 'Error'
+  [BudgetLevel.ERROR]: 'Error',
+  hash: 'Hash'
 };
 
-const levelToEmoji = {
+export const levelToEmoji = {
   [BudgetLevel.WARN]: '⚠️',
-  [BudgetLevel.ERROR]: '🚨'
+  [BudgetLevel.ERROR]: '🚨',
+  hash: '#️⃣'
 };
 
-export function formatBudgetResult(budgetResult: BudgetResult, itemName: string, useEmoji = false): string {
+function getPrefix(artifactName: string, level: string, useEmoji = false): string {
+  return `${(useEmoji ? levelToEmoji : levelToString)[level]}: \`${artifactName}\``;
+}
+
+export function formatBudgetResult(budgetResult: BudgetResult, artifactName: string, useEmoji = false): string {
   const { actual, expected, level, sizeKey, type } = budgetResult;
   const actualFormatted = type === BudgetType.PERCENT_DELTA ? formatPercent(actual) : formatBytes(actual);
   const expectedFormatted = type === BudgetType.PERCENT_DELTA ? formatPercent(expected) : formatBytes(expected);
   const diffFormatted =
     type === BudgetType.PERCENT_DELTA ? formatPercent(actual - expected) : formatBytes(actual - expected);
 
-  const prefix = `${(useEmoji ? levelToEmoji : levelToString)[level]}: \`${itemName}\``;
+  const prefix = getPrefix(artifactName, level, useEmoji);
 
   switch (type) {
     case BudgetType.DELTA:
@@ -60,4 +66,9 @@ export function formatBudgetResult(budgetResult: BudgetResult, itemName: string,
     case BudgetType.SIZE:
       return `${prefix} failed the ${sizeKey} budget size limit of ${expectedFormatted} by ${diffFormatted}`;
   }
+}
+
+export function formatUnexpectedHashChange(artifactName: string, useEmoji = false): string {
+  const prefix = getPrefix(artifactName, 'hash', useEmoji);
+  return `${prefix} hash changed without any file size change`;
 }


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

* Unexpected hash changes are not denoted in markdown tables
* They share the same icon in the UI as regular budget warnings

# Solution

Fixes #151

* Unify the "error" emoji to 🚨
* Use #️⃣ for unexpected hash changes in markdown table and summaries
* Add an icon the looks like #️⃣ to the app UI, use that instead of warning icon

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
