### PR TITLE
[server] add api insert validation

### DIFF
--- a/docs/docs/packages/api-errors.md
+++ b/docs/docs/packages/api-errors.md
@@ -6,6 +6,10 @@ sidebar_label: '@build-tracker/api-errors'
 
 This is a shared package for creating and comparing API errors returned from the Build Tracker server's API.
 
+## 400 `ValidationError`
+
+The build that you are trying to insert into the database does not meet requirements. See the specific error message for more information.
+
 ## 401 `AuthError`
 
 If your server's API is protected with an API key and you do not provide it with requests requiring authentication, a 401 unauthorized response will be returned.

--- a/src/api-errors/src/index.ts
+++ b/src/api-errors/src/index.ts
@@ -28,3 +28,12 @@ export class UnimplementedError extends Error {
     Object.setPrototypeOf(this, UnimplementedError.prototype);
   }
 }
+
+export class ValidationError extends Error {
+  public readonly status = 400;
+
+  public constructor(field: string, expected: string, received: string | number | void) {
+    super(`"${field}" expected to receive "${expected}", but value was "${received}"`);
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}

--- a/src/server/src/api/__tests__/insert.test.ts
+++ b/src/server/src/api/__tests__/insert.test.ts
@@ -84,6 +84,24 @@ describe('insert build handler', () => {
           expect(res.body.summary).toEqual(comparator.toSummary());
         });
     });
+
+    test('returns an array of validation errors', () => {
+      const handler = insertBuild(queries, config);
+      app.post('/test', handler);
+
+      return request(app)
+        .post('/test')
+        .send({ meta: { timestamp: 'foobar' }, artifacts: [] })
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .then(res => {
+          expect(res.status).toEqual(400);
+          expect(res.body.errors).toEqual([
+            '"revision" expected to receive "string", but value was "undefined"',
+            '"timestamp" expected to receive "timestamp", but value was "foobar"'
+          ]);
+        });
+    });
   });
 
   describe('parent revision', () => {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

There's no validation on `insert` of a build using the API.

# Solution

Add remedial validation to the two most important fields, `revision` and `timestamp`
fixes #25 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
