### PR TITLE
[cli] add --meta option for passing extra data into a build

### DIFF
--- a/docs/docs/packages/cli.md
+++ b/docs/docs/packages/cli.md
@@ -170,23 +170,26 @@ Beside the arguments below, if you're running your server with a [`BT_API_AUTH_T
 BT_API_AUTH_TOKEN=my-secret-token bt-cli upload-build
 ```
 
-| option, alias        | description                                             | default                       |
-| -------------------- | ------------------------------------------------------- | ----------------------------- |
-| `--branch`, `-b`     | Set the branch name and do not attempt to read from git | Current git working branch    |
-| `--config`, `-c`     | Set path to the build-tracker CLI config file           | `./build-tracker.config.js`   |
-| `--out`, `-o`        | Write the build to stdout                               | `true`                        |
-| `--parent-revision`  | Manually set the parent revision for the comparison.    | Determined via git-merge-base |
-| `--skip-dirty-check` | Skip the git work tree state check                      | `false`                       |
+| option, alias        | description                                                | default                       |
+| -------------------- | ---------------------------------------------------------- | ----------------------------- |
+| `--branch`, `-b`     | Set the branch name and do not attempt to read from git    | Current git working branch    |
+| `--config`, `-c`     | Set path to the build-tracker CLI config file              | `./build-tracker.config.js`   |
+| `--meta`             | JSON-encoded extra meta information to attach to the build |                               |
+| `--parent-revision`  | Manually set the parent revision for the comparison.       | Determined via git-merge-base |
+| `--skip-dirty-check` | Skip the git work tree state check                         | `false`                       |
 
 ### `create-build`
 
 This command will create a Build object for the current available build. If run independently, it will only output information, but not upload it anywhere. For that, you only need to run `yarn bt-cli upload-build`.
 
-| option, alias        | description                                             | default                     |
-| -------------------- | ------------------------------------------------------- | --------------------------- |
-| `--branch`, `-b`     | Set the branch name and do not attempt to read from git | Current git working branch  |
-| `--config`, `-c`     | Set path to the build-tracker CLI config file           | `./build-tracker.config.js` |
-| `--skip-dirty-check` | Skip the git work tree state check                      | `false`                     |
+| option, alias        | description                                                | default                       |
+| -------------------- | ---------------------------------------------------------- | ----------------------------- |
+| `--branch`, `-b`     | Set the branch name and do not attempt to read from git    | Current git working branch    |
+| `--config`, `-c`     | Set path to the build-tracker CLI config file              | `./build-tracker.config.js`   |
+| `--meta`             | JSON-encoded extra meta information to attach to the build |                               |
+| `--out`, `-o`        | Write the build to stdout                                  | `true`                        |
+| `--parent-revision`  | Manually set the parent revision for the comparison.       | Determined via git-merge-base |
+| `--skip-dirty-check` | Skip the git work tree state check                         | `false`                       |
 
 ### `stat-artifacts`
 

--- a/src/cli/src/commands/__tests__/create-build.test.ts
+++ b/src/cli/src/commands/__tests__/create-build.test.ts
@@ -158,5 +158,18 @@ describe('create-build', () => {
         }
       });
     });
+
+    test('can include JSON encoded extra meta', async () => {
+      await expect(
+        Command.handler({
+          config,
+          out: false,
+          meta: '{"foo":"bar","baz":{"url":"https://buildtracker.dev","value":"baz"}}',
+          'skip-dirty-check': true
+        })
+      ).resolves.toMatchObject({
+        meta: { revision: 'abcdefg', foo: 'bar', baz: { url: 'https://buildtracker.dev', value: 'baz' } }
+      });
+    });
   });
 });

--- a/src/cli/src/commands/create-build.ts
+++ b/src/cli/src/commands/create-build.ts
@@ -12,9 +12,10 @@ export const command = 'create-build';
 
 export const description = 'Construct a build for the current commit';
 
-interface Args {
+export interface Args {
   branch?: string;
   config?: string;
+  meta?: string;
   out: boolean;
   'parent-revision'?: string;
   'skip-dirty-check': boolean;
@@ -22,9 +23,8 @@ interface Args {
 
 const group = 'Create a build';
 
-export const builder = (yargs): Argv<Args> =>
+export const getBuildOptions = (yargs): Argv<Args> =>
   yargs
-    .usage(`Usage: $0 ${command}`)
     .option('branch', {
       alias: 'b',
       description: 'Set the branch name and do not attempt to read from git',
@@ -37,12 +37,10 @@ export const builder = (yargs): Argv<Args> =>
       group,
       normalize: true
     })
-    .option('out', {
-      alias: 'o',
-      default: true,
-      description: 'Write the build to stdout',
+    .option('meta', {
+      description: 'JSON-encoded extra meta information to attach to the build',
       group,
-      type: 'boolean'
+      type: 'string'
     })
     .option('parent-revision', {
       description: 'Manually provide the parent revision instead of reading it automatically',
@@ -52,6 +50,17 @@ export const builder = (yargs): Argv<Args> =>
     .option('skip-dirty-check', {
       default: false,
       description: 'Skip the git work tree state check',
+      group,
+      type: 'boolean'
+    });
+
+export const builder = (yargs): Argv<Args> =>
+  getBuildOptions(yargs)
+    .usage(`Usage: $0 ${command}`)
+    .option('out', {
+      alias: 'o',
+      default: true,
+      description: 'Write the build to stdout',
       group,
       type: 'boolean'
     });
@@ -106,6 +115,8 @@ export const handler = async (args: Args): Promise<{}> => {
     }
   }
 
+  const meta = args.meta ? JSON.parse(args.meta) : {};
+
   const build = {
     meta: {
       author: name,
@@ -113,7 +124,8 @@ export const handler = async (args: Args): Promise<{}> => {
       parentRevision,
       revision,
       subject,
-      timestamp
+      timestamp,
+      ...meta
     },
     artifacts
   };

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -2,55 +2,23 @@
  * Copyright (c) 2019 Paul Armstrong
  */
 import { Argv } from 'yargs';
-import { handler as createBuild } from './create-build';
 import http from 'http';
 import https from 'https';
 import { URL } from 'url';
+import { Args as BuildArgs, handler as createBuildHandler, getBuildOptions } from './create-build';
 import getConfig, { ApiReturn } from '../modules/config';
 
 export const command = 'upload-build';
 
 export const description = 'Upload a build for the current commit';
 
-interface Args {
-  branch?: string;
-  config?: string;
-  out: boolean;
-  'skip-dirty-check': boolean;
-}
+type Args = BuildArgs;
 
-const group = 'Create a build';
-
-export const builder = (yargs): Argv<Args> =>
-  yargs
-    .usage(`Usage: $0 ${command}`)
-    .option('branch', {
-      alias: 'b',
-      description: 'Set the branch name and do not attempt to read from git',
-      group,
-      type: 'string'
-    })
-    .option('config', {
-      alias: 'c',
-      description: 'Override path to the build-tracker CLI config file',
-      group,
-      normalize: true
-    })
-    .option('parent-revision', {
-      description: 'Manually provide the parent revision instead of reading it automatically',
-      group,
-      type: 'string'
-    })
-    .option('skip-dirty-check', {
-      default: false,
-      description: 'Skip the git work tree state check',
-      group,
-      type: 'boolean'
-    });
+export const builder = (yargs): Argv<Args> => getBuildOptions(yargs).usage(`Usage: $0 ${command}`);
 
 export const handler = async (args: Args): Promise<void> => {
   const config = await getConfig(args.config);
-  const build = await createBuild({ ...args, out: false });
+  const build = await createBuildHandler({ ...args, out: false });
 
   const url = new URL(`${config.applicationUrl}/api/builds`);
   const httpProtocol = config.applicationUrl.startsWith('https:') ? https : http;


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Build Meta can accept any arbitrary data and display it in the UI, assuming it matches the format `{ [key: string]: string | { url: string, value: string } }`. Unfortunately, the CLI does not have any way to set this information.

# Solution

* Adds a `--meta` option that takes a string of JSON-encoded, parses it, and attaches it to the Build.
* Unifies the arguments that are shared between `create-build` and `upload-build`

Fixes #150 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
