### PR TITLE
[fix] Export TS declaration files

### DIFF
--- a/plugins/with-mariadb/package.json
+++ b/plugins/with-mariadb/package.json
@@ -7,7 +7,11 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/plugins/with-mariadb/package.json
+++ b/plugins/with-mariadb/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/plugins/with-mysql/package.json
+++ b/plugins/with-mysql/package.json
@@ -7,7 +7,11 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/plugins/with-mysql/package.json
+++ b/plugins/with-mysql/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/plugins/with-postgres/package.json
+++ b/plugins/with-postgres/package.json
@@ -7,7 +7,11 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/plugins/with-postgres/package.json
+++ b/plugins/with-postgres/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/api-client/package.json
+++ b/src/api-client/package.json
@@ -5,12 +5,13 @@
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "repository": "git@github.com:paularmstrong/build-tracker.git",
   "license": "MIT",
-  "bin": {
-    "bt-cli": "./dist/bin.js"
-  },
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/api-client/package.json
+++ b/src/api-client/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/api-client/package.json
+++ b/src/api-client/package.json
@@ -10,6 +10,7 @@
   },
   "main": "dist",
   "module": "./",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/api-errors/package.json
+++ b/src/api-errors/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/api-errors/package.json
+++ b/src/api-errors/package.json
@@ -8,6 +8,8 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/api-errors/package.json
+++ b/src/api-errors/package.json
@@ -8,6 +8,10 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/app/config/webpack-client.config.js
+++ b/src/app/config/webpack-client.config.js
@@ -37,6 +37,7 @@ module.exports = (env, reporter) => ({
     global: false
   },
   optimization: {
+    sideEffects: true,
     splitChunks: {
       cacheGroups: {
         vendor: {

--- a/src/app/config/webpack-server.config.js
+++ b/src/app/config/webpack-server.config.js
@@ -40,6 +40,7 @@ module.exports = (env, reporter) => ({
   },
   optimization: {
     minimize: false,
+    sideEffects: true,
     splitChunks: {}
   },
   output: {

--- a/src/app/tsconfig.json
+++ b/src/app/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "module": "esnext"
+    "module": "esnext",
+    "outDir": "./dist"
   },
   "include": ["src", "../build", "../comparator", "../fixtures", "../formatting", "../types"]
 }

--- a/src/build/package.json
+++ b/src/build/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/build/package.json
+++ b/src/build/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/build/package.json
+++ b/src/build/package.json
@@ -8,6 +8,10 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -11,6 +11,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -10,6 +10,7 @@
   },
   "main": "dist",
   "module": "./",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -11,6 +11,9 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -8,6 +8,10 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/comparator/package.json
+++ b/src/comparator/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "index.js",
     "dist"

--- a/src/fixtures/index.js
+++ b/src/fixtures/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/fixtures/package.json
+++ b/src/fixtures/package.json
@@ -5,9 +5,8 @@
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "repository": "git@github.com:paularmstrong/build-tracker.git",
   "license": "MIT",
-  "main": "dist",
+  "main": "./",
   "module": "./",
-  "types": "dist/index.ts",
   "dependencies": {
     "glob": "^7.1.3"
   },

--- a/src/fixtures/package.json
+++ b/src/fixtures/package.json
@@ -5,7 +5,9 @@
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "repository": "git@github.com:paularmstrong/build-tracker.git",
   "license": "MIT",
-  "types": "index.ts",
+  "main": "dist",
+  "module": "./",
+  "types": "dist/index.ts",
   "dependencies": {
     "glob": "^7.1.3"
   },

--- a/src/formatting/package.json
+++ b/src/formatting/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/formatting/package.json
+++ b/src/formatting/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/formatting/package.json
+++ b/src/formatting/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -11,6 +11,7 @@
   "main": "dist/server.js",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -10,7 +10,7 @@
   },
   "main": "dist/server.js",
   "module": "./",
-  "types": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "index.js",
     "dist"

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -9,7 +9,8 @@
     "bt-server": "dist/index.js"
   },
   "main": "dist/server.js",
-  "types": "index.ts",
+  "module": "./",
+  "types": "dist/index.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -11,6 +11,10 @@
   "main": "dist/server.js",
   "module": "./",
   "types": "dist/index.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -10,7 +10,7 @@
   },
   "main": "dist/server.js",
   "module": "./",
-  "types": "dist/index.d.ts",
+  "types": "dist/server.d.ts",
   "sideEffects": false,
   "files": [
     "index.js",

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -8,6 +8,10 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.ts",
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist"

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "index.ts",
+  "types": "dist/index.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist"

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -8,6 +8,7 @@
   "main": "dist",
   "module": "./",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "index.js",
     "dist"

--- a/src/types/package.json
+++ b/src/types/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "dist",
   "module": "./",
-  "types": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "index.js",
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,17 +26,5 @@
       "react-native": ["./typings/react-native"]
     }
   },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**", "plugins/**/dist/**"],
-  "references": [
-    { "path": "src/api-client" },
-    { "path": "src/api-errors" },
-    { "path": "src/api-app" },
-    { "path": "src/api-build" },
-    { "path": "src/api-cli" },
-    { "path": "src/api-comparator" },
-    { "path": "src/api-fixtures" },
-    { "path": "src/api-formatting" },
-    { "path": "src/api-server" },
-    { "path": "src/api-types" }
-  ]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**", "plugins/**/dist/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "checkJs": false,
+    "declaration": true,
     "esModuleInterop": true,
     "jsx": "react",
     "lib": ["esnext", "dom"],
@@ -24,5 +25,17 @@
       "react-native": ["./typings/react-native"]
     }
   },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**", "plugins/**/dist/**"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/*/dist/**", "plugins/**/dist/**"],
+  "references": [
+    { "path": "src/api-client" },
+    { "path": "src/api-errors" },
+    { "path": "src/api-app" },
+    { "path": "src/api-build" },
+    { "path": "src/api-cli" },
+    { "path": "src/api-comparator" },
+    { "path": "src/api-fixtures" },
+    { "path": "src/api-formatting" },
+    { "path": "src/api-server" },
+    { "path": "src/api-types" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "checkJs": false,
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "jsx": "react",
     "lib": ["esnext", "dom"],


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

<!--
Explain the problem that this pull request aims to resolve.
-->

(From #105, per @OliverJAsh )
The `types` field in the `package.json` of `@build-tracker/plugin-with-postgres` currently refers to the TS _source code_:

https://github.com/paularmstrong/build-tracker/blob/f66274bba0003e58cd2922b759cc883222e21ac9/plugins/with-postgres/package.json#L10

This means that TS users who import from this module will get lots of errors relating to the source code.

It would be better if the `types` field instead just referred to some declaration files (`.d.ts`). These could be generated using the `declaration` compiler option. This way, users will only import the types—they won't be forced to type check the actual source code itself.


# Solution

Using `declarations: true` in the root `tsconfig.json` seems to ensure the declaration files are built, but references in the monorepo seem to keep up-to-date with what is in the `src` folder for each workspace, thanks to the `"module": "./"` in each `package.json` and the root `index.ts` file referencing the `src` directory.

This presented a small problem in that we want to make sure that file isn't included in the build. I've also added `files: ['dist', 'index.js']` to each (appropriate) `package.json`. 

It looks like publishing works as expected
<img width="433" alt="Screen Shot 2020-03-15 at 8 24 44 AM" src="https://user-images.githubusercontent.com/33297/76704466-7a3a7380-6696-11ea-8c3f-d7206648cc69.png">

Fixes #105 
Closes #117, #118 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
