### PR TITLE
[chore] add README files that point to the docs

### DIFF
--- a/plugins/with-mariadb/README.md
+++ b/plugins/with-mariadb/README.md
@@ -1,53 +1,5 @@
 # @build-tracker/plugin-with-mariadb
 
-A server-configuration plugin for Build Tracker to enable reading build data from a MariaDB database.
+> A server-configuration plugin for Build Tracker to enable reading build data from a MariaDB database.
 
-Connecting your Build Tracker application to a Maria database is easy with the help of `@build-tracker/plugin-with-mariadb`
-
-## Installation
-
-```sh
-yarn add @build-tracker/plugin-with-mariadb@latest
-# or
-npm install --save @build-tracker/plugin-with-mariadb@latest
-```
-
-## Configuration
-
-Edit your `build-tracker.config.js` file and compose your output configuration:
-
-```js
-const withMariadb = require('@build-tracker/plugin-with-mariadb');
-
-module.exports = withMariadb({
-  mariadb: {
-    user: '', // default: process.env.MARIAUSER
-    host: '', // default: process.env.MARIAHOST
-    database: '', // default: process.env.MARIADATABASE
-    password: '', // default: process.env.MARIAPASSWORD
-    port: 3306 // default: process.env.MARIAPORT
-  }
-});
-```
-
-All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
-
-### `host: string = process.env.MARIAHOST`
-
-Database host.
-
-### `database: string = process.env.MARIAPASSWORD`
-
-Database name.
-
-### `user: string = process.env.MARIAUSER`
-
-Database username with read access.
-
-### `password: string = process.env.MARIADATABASE`
-
-Password for the given database username.
-
-### `port: number = process.env.MARIAPORT = 3306`
-
-Database host port.
+Read the [documentation online](https://buildtracker.dev/docs/plugins/withMariadb) for more information on getting started with Build Tracker.

--- a/plugins/with-mysql/README.md
+++ b/plugins/with-mysql/README.md
@@ -1,53 +1,5 @@
 # @build-tracker/plugin-with-mysql
 
-A server-configuration plugin for Build Tracker to enable reading build data from a MySQL database.
+> A server-configuration plugin for Build Tracker to enable reading build data from a MySQL database.
 
-Connecting your Build Tracker application to a MySQL database is easy with the help of `@build-tracker/plugin-with-mysql`
-
-## Installation
-
-```sh
-yarn add @build-tracker/plugin-with-mysql@latest
-# or
-npm install --save @build-tracker/plugin-with-mysql@latest
-```
-
-## Configuration
-
-Edit your `build-tracker.config.js` file and compose your output configuration:
-
-```js
-const withMysql = require('@build-tracker/plugin-with-mysql');
-
-module.exports = withMysql({
-  mysql: {
-    user: '', // default: process.env.MYSQLUSER
-    host: '', // default: process.env.MYSQLHOST
-    database: '', // default: process.env.MYSQLDATABASE
-    password: '', // default: process.env.MYSQLPASSWORD
-    port: 3306 // default: process.env.MYSQLPORT
-  }
-});
-```
-
-All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
-
-### `host: string = process.env.MYSQLHOST`
-
-Database host.
-
-### `database: string = process.env.MYSQLPASSWORD`
-
-Database name.
-
-### `user: string = process.env.MYSQLUSER`
-
-Database username with read access.
-
-### `password: string = process.env.MYSQLDATABASE`
-
-Password for the given database username.
-
-### `port: number = process.env.MYSQLPORT = 3306`
-
-Database host port.
+Read the [documentation online](https://buildtracker.dev/docs/plugins/withMysql) for more information on getting started with Build Tracker.

--- a/plugins/with-postgres/README.md
+++ b/plugins/with-postgres/README.md
@@ -1,53 +1,5 @@
 # @build-tracker/plugin-with-postgres
 
-A server-configuration plugin for Build Tracker to enable reading build data from a Postgres database.
+> A server-configuration plugin for Build Tracker to enable reading build data from a PostgreSQL database.
 
-Wrap your server's `build-tracker.config.js` configuration with `withPostgres` and include the `pg` options object:
-
-```js
-const withPostgres = require('@build-tracker/plugin-with-postgres');
-
-module.exports = withPostgres({
-  pg: {
-    connectionString: '', // default: process.env.DATABASE_URL
-    user: '', // default: process.env.PGUSER
-    host: '', // default: process.env.PGHOST
-    database: '', // default: process.env.PGPASSWORD
-    password: '', // default: process.env.PGDATABASE
-    port: 5432, // default: process.env.PGPORT
-    ssl: true
-  }
-});
-```
-
-## Configuration
-
-All configuration options that are able to fall back on `process.env` environment variables can be written to your systems `ENV` or to a local `.env` file via [dotenv](https://github.com/motdotla/dotenv#readme).
-
-### `connectionString: string = process.env.DATABASE_URL`
-
-Optional. Use a single connection string to bypass the individual configs for `host`, `database`, `user`, `password`, and `port`.
-
-### `host: string = process.env.PGHOST`
-
-Database host.
-
-### `database: string = process.env.PGPASSWORD`
-
-Database name.
-
-### `user: string = process.env.PGUSER`
-
-Database username with read access.
-
-### `password: string = process.env.PGDATABASE`
-
-Password for the given database username.
-
-### `port: number = process.env.PGPORT = 5432`
-
-Database host port.
-
-### `ssl: boolean = false`
-
-Set to true to connect to your host using SSL (if supported).
+Read the [documentation online](https://buildtracker.dev/docs/plugins/withPostgres) for more information on getting started with Build Tracker.

--- a/src/api-client/README.md
+++ b/src/api-client/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/api-client
+
+> A suite of tools for interfacing with a [Build Tracker](https://buildtracker.dev) instance's API.
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/api-client) for more information on getting started with Build Tracker.

--- a/src/api-errors/README.md
+++ b/src/api-errors/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/api-errors
+
+> A comprehensive list of error types that may be returned from a [Build Tracker](https://buildtracker.dev) instance's API.
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/api-errors) for more information on getting started with Build Tracker.

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/app
+
+> A React.js client-side application for [Build Tracker](https://buildtracker.dev).
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/app) for more information on getting started with Build Tracker.

--- a/src/build/README.md
+++ b/src/build/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/build
+
+> A shareable representation of a single `build` used in [Build Tracker](https://buildtracker.dev).
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/build) for more information on getting started with Build Tracker.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/cli
+
+> A command-line interface for interacting with a [Build Tracker](https://buildtracker.dev) instance's API.
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/cli) for more information on getting started with Build Tracker.

--- a/src/comparator/README.md
+++ b/src/comparator/README.md
@@ -1,11 +1,5 @@
-# `comparator`
+# @build-tracker/comparator
 
-> TODO: description
+> The [Build Tracker](https://buildtracker.dev) Comparator contains the core functionality for calculating how two or more Builds differ. This package is only needed individually if you would like to do some custom reporting on various Builds.
 
-## Usage
-
-```
-const comparator = require('comparator');
-
-// TODO: DEMONSTRATE API
-```
+Read the [documentation online](https://buildtracker.dev/docs/packages/comparator) for more information on getting started with Build Tracker.

--- a/src/fixtures/README.md
+++ b/src/fixtures/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/fixtures
+
+> Static data for testing and developing [Build Tracker](https://buildtracker.dev).
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/fixtures) for more information on getting started with Build Tracker.

--- a/src/formatting/README.md
+++ b/src/formatting/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/formatting
+
+> String formatters for making [Build Tracker](https://buildtracker.dev) data human-readable.
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/formatting) for more information on getting started with Build Tracker.

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/server
+
+> Runs a [Build Tracker](https://buildtracker.dev) web application (`@build-tracker/app`) using a Node.js server.
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/server) for more information on getting started with Build Tracker.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,0 +1,5 @@
+# @build-tracker/types
+
+> Shared types and enums used throughout [Build Tracker](https://buildtracker.dev).
+
+Read the [documentation online](https://buildtracker.dev/docs/packages/types) for more information on getting started with Build Tracker.


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

There are no README files in published versions, which is not great when looking on yarnpkg.com or npmjs.com

# Solution

I don't really want to keep every README up to date with docs as well as the actual docs site. For now, just giving a short description and pointing to the buildtracker.dev site.

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
