### PR TITLE
[app] add tooltips to graph when hovering

### DIFF
--- a/src/app/src/components/ComparisonTable/ArtifactCell.tsx
+++ b/src/app/src/components/ComparisonTable/ArtifactCell.tsx
@@ -5,8 +5,8 @@ import * as Theme from '../../theme';
 import Hoverable from '../Hoverable';
 import { hsl } from 'd3-color';
 import React from 'react';
+import RelativeTooltip from '../RelativeTooltip';
 import { Th } from '../Table';
-import Tooltip from '../Tooltip';
 import { ArtifactCell as ACell, GroupCell as GCell } from '@build-tracker/comparator';
 import { StyleProp, StyleSheet, Switch, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 
@@ -61,7 +61,7 @@ export const ArtifactCell = (props: Props): React.ReactElement => {
                   {text}
                 </Text>
               </TouchableOpacity>
-              {isHovered ? <Tooltip relativeTo={textRef} text={`Show "${text}" only`} /> : null}
+              {isHovered ? <RelativeTooltip relativeTo={textRef} text={`Show "${text}" only`} /> : null}
             </View>
           )}
         </Hoverable>

--- a/src/app/src/components/ComparisonTable/DeltaCell.tsx
+++ b/src/app/src/components/ComparisonTable/DeltaCell.tsx
@@ -6,8 +6,8 @@ import ErrorIcon from '../../icons/Error';
 import HashIcon from '../../icons/Hash';
 import Hoverable from '../Hoverable';
 import React from 'react';
+import RelativeTooltip from '../RelativeTooltip';
 import { Td } from '../Table';
-import Tooltip from '../Tooltip';
 import WarningIcon from '../../icons/Warning';
 import { DeltaCell as Cell, TotalDeltaCell as TDCell } from '@build-tracker/comparator';
 import { formatBudgetResult, formatBytes, formatUnexpectedHashChange } from '@build-tracker/formatting';
@@ -99,7 +99,7 @@ export const DeltaCell = (props: Props): React.ReactElement => {
                 </Text>
               ) : null}
               {sizeDelta !== 0 ? <Text>{text}</Text> : null}
-              {isHovered ? <Tooltip relativeTo={viewRef} text={tooltipText} /> : null}
+              {isHovered ? <RelativeTooltip relativeTo={viewRef} text={tooltipText} /> : null}
             </View>
           )}
         </Hoverable>

--- a/src/app/src/components/ComparisonTable/GroupCell.tsx
+++ b/src/app/src/components/ComparisonTable/GroupCell.tsx
@@ -6,8 +6,8 @@ import FolderIcon from '../../icons/Folder';
 import { GroupCell as GCell } from '@build-tracker/comparator';
 import Hoverable from '../Hoverable';
 import React from 'react';
+import RelativeTooltip from '../RelativeTooltip';
 import { Th } from '../Table';
-import Tooltip from '../Tooltip';
 import { StyleProp, StyleSheet, Switch, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 
 interface Props {
@@ -54,7 +54,7 @@ export const GroupCell = (props: Props): React.ReactElement => {
                 <Text style={isHovered && styles.hoveredText}>
                   <FolderIcon style={[styles.folder, isHovered && styles.hoveredText]} testID="groupicon" /> {text}
                 </Text>
-                {isHovered ? <Tooltip relativeTo={nameRef} text={`${artifactNames.join(', ')}`} /> : null}
+                {isHovered ? <RelativeTooltip relativeTo={nameRef} text={`${artifactNames.join(', ')}`} /> : null}
               </View>
             </TouchableOpacity>
           )}

--- a/src/app/src/components/ComparisonTable/RevisionDeltaCell.tsx
+++ b/src/app/src/components/ComparisonTable/RevisionDeltaCell.tsx
@@ -5,8 +5,8 @@ import { RevisionDeltaCell as Cell } from '@build-tracker/comparator';
 import { formatSha } from '@build-tracker/formatting';
 import Hoverable from '../Hoverable';
 import React from 'react';
+import RelativeTooltip from '../RelativeTooltip';
 import { Th } from '../Table';
-import Tooltip from '../Tooltip';
 import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native';
 
 interface Props {
@@ -25,7 +25,7 @@ export const RevisionDeltaCell = (props: Props): React.ReactElement => {
           <View ref={viewRef} testID="delta">
             <Text style={styles.delta}>{`𝚫${deltaIndex}`}</Text>
             {isHovered ? (
-              <Tooltip
+              <RelativeTooltip
                 relativeTo={viewRef}
                 text={`Delta from ${formatSha(againstRevision)} to ${formatSha(revision)}`}
               />

--- a/src/app/src/components/RelativeTooltip.tsx
+++ b/src/app/src/components/RelativeTooltip.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import React from 'react';
+import Tooltip from './Tooltip';
+import { View } from 'react-native';
+
+interface Props {
+  relativeTo: React.RefObject<View>;
+  text: string;
+}
+
+const RelativeTooltip = (props: Props): React.ReactElement => {
+  const { relativeTo, text } = props;
+  const [position, setPosition] = React.useState({ top: -999, left: 0 });
+
+  React.useEffect(() => {
+    let mounted = true;
+    if (relativeTo.current) {
+      relativeTo.current.measureInWindow(
+        (x: number, y: number, width: number, height: number): void => {
+          if (!mounted) {
+            return;
+          }
+
+          setPosition({ left: x + Math.round(width / 2), top: y + Math.round(height / 2) });
+        }
+      );
+    }
+    return () => {
+      mounted = false;
+    };
+    /* eslint-disable react-hooks/exhaustive-deps */
+    // Tests break if you pass the ref/relativeTo higher object in and not the actual value we're using
+  }, [relativeTo.current]);
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  return <Tooltip left={position.left} top={position.top} text={text} />;
+};
+
+export default RelativeTooltip;

--- a/src/app/src/components/__tests__/RelativeTooltip.test.tsx
+++ b/src/app/src/components/__tests__/RelativeTooltip.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import React from 'react';
+import RelativeTooltip from '../RelativeTooltip';
+import { render } from '@testing-library/react';
+import { MeasureOnSuccessCallback, View } from 'react-native';
+
+describe('RelativeTooltip', () => {
+  let viewRef;
+  beforeEach(() => {
+    viewRef = React.createRef();
+    render(<View ref={viewRef} />);
+  });
+
+  test('renders a tooltip to a portal', () => {
+    const portal = document.createElement('div');
+    portal.setAttribute('id', 'tooltipPortal');
+    document.body.appendChild(portal);
+
+    jest.spyOn(View.prototype, 'measure').mockImplementation(
+      (fn: MeasureOnSuccessCallback): void => {
+        fn(0, 0, 45, 20, 0, 0);
+      }
+    );
+    jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
+      (fn: (x: number, y: number, width: number, height: number) => void): void => {
+        fn(20, 100, 40, 30);
+      }
+    );
+
+    const { getByRole, queryAllByText } = render(<RelativeTooltip relativeTo={viewRef} text="foobar" />, {
+      container: portal
+    });
+
+    expect(getByRole('tooltip').style).toMatchObject({
+      top: '89px',
+      left: '17px'
+    });
+    expect(queryAllByText('foobar')).toHaveLength(1);
+    document.body.removeChild(portal);
+  });
+
+  test('renders directly without a portal available', () => {
+    jest.spyOn(View.prototype, 'measure').mockImplementation(
+      (fn: MeasureOnSuccessCallback): void => {
+        fn(0, 0, 45, 20, 0, 0);
+      }
+    );
+
+    jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
+      (fn: (x: number, y: number, width: number, height: number) => void): void => {
+        fn(20, 100, 40, 30);
+      }
+    );
+
+    const { getByRole, queryAllByText } = render(<RelativeTooltip relativeTo={viewRef} text="foobar" />);
+
+    expect(getByRole('tooltip').style).toMatchObject({
+      top: '89px',
+      left: '17px'
+    });
+    expect(queryAllByText('foobar')).toHaveLength(1);
+  });
+});

--- a/src/app/src/components/__tests__/Tooltip.test.tsx
+++ b/src/app/src/components/__tests__/Tooltip.test.tsx
@@ -7,12 +7,6 @@ import Tooltip from '../Tooltip';
 import { Dimensions, MeasureOnSuccessCallback, View } from 'react-native';
 
 describe('Tooltip', () => {
-  let viewRef;
-  beforeEach(() => {
-    viewRef = React.createRef();
-    render(<View ref={viewRef} />);
-  });
-
   test('renders a tooltip to a portal', () => {
     const portal = document.createElement('div');
     portal.setAttribute('id', 'tooltipPortal');
@@ -23,21 +17,17 @@ describe('Tooltip', () => {
         fn(0, 0, 45, 20, 0, 0);
       }
     );
-    jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
-      (fn: (x: number, y: number, width: number, height: number) => void): void => {
-        fn(20, 100, 40, 30);
-      }
-    );
 
-    const { getByRole, queryAllByText } = render(<Tooltip relativeTo={viewRef} text="foobar" />, {
+    const { getByRole, queryAllByText } = render(<Tooltip left={20} top={100} text="foobar" />, {
       container: portal
     });
 
     expect(getByRole('tooltip').style).toMatchObject({
-      top: '136px',
-      left: '17.5px'
+      top: '90px',
+      left: '26px'
     });
     expect(queryAllByText('foobar')).toHaveLength(1);
+    document.body.removeChild(portal);
   });
 
   test('renders directly without a portal available', () => {
@@ -47,17 +37,11 @@ describe('Tooltip', () => {
       }
     );
 
-    jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
-      (fn: (x: number, y: number, width: number, height: number) => void): void => {
-        fn(20, 100, 40, 30);
-      }
-    );
-
-    const { getByRole, queryAllByText } = render(<Tooltip relativeTo={viewRef} text="foobar" />);
+    const { getByRole, queryAllByText } = render(<Tooltip left={20} top={100} text="foobar" />);
 
     expect(getByRole('tooltip').style).toMatchObject({
-      top: '136px',
-      left: '17.5px'
+      top: '90px',
+      left: '26px'
     });
     expect(queryAllByText('foobar')).toHaveLength(1);
   });
@@ -70,17 +54,12 @@ describe('Tooltip', () => {
           fn(0, 0, 45, 30, 0, 0);
         }
       );
-      jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
-        (fn: (x: number, y: number, width: number, height: number) => void): void => {
-          fn(10, 200, 20, 10);
-        }
-      );
 
-      const { getByRole } = render(<Tooltip relativeTo={viewRef} text="foobar" />);
+      const { getByRole } = render(<Tooltip left={10} top={200} text="foobar" />);
 
       expect(getByRole('tooltip').style).toMatchObject({
-        top: '190px',
-        left: '36px'
+        top: '185px',
+        left: '16px'
       });
     });
 
@@ -91,38 +70,27 @@ describe('Tooltip', () => {
           fn(0, 0, 45, 30, 0, 0);
         }
       );
-      jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
-        (fn: (x: number, y: number, width: number, height: number) => void): void => {
-          fn(380, 200, 50, 10);
-        }
-      );
 
-      const { getByRole } = render(<Tooltip relativeTo={viewRef} text="foobar" />);
+      const { getByRole } = render(<Tooltip left={380} top={200} text="foobar" />);
 
       expect(getByRole('tooltip').style).toMatchObject({
-        top: '190px',
+        top: '185px',
         left: '329px'
       });
     });
 
-    test('avoids the bottom edge', () => {
+    test('avoids the top edge', () => {
       jest.spyOn(Dimensions, 'get').mockReturnValue({ width: 400, height: 400, scale: 1, fontScale: 1 });
       jest.spyOn(View.prototype, 'measure').mockImplementation(
         (fn: MeasureOnSuccessCallback): void => {
           fn(0, 0, 45, 30, 0, 0);
         }
       );
-      jest.spyOn(View.prototype, 'measureInWindow').mockImplementation(
-        (fn: (x: number, y: number, width: number, height: number) => void): void => {
-          fn(200, 380, 50, 10);
-        }
-      );
-
-      const { getByRole } = render(<Tooltip relativeTo={viewRef} text="foobar" />);
+      const { getByRole } = render(<Tooltip left={200} top={0} text="foobar" />);
 
       expect(getByRole('tooltip').style).toMatchObject({
-        top: '344px',
-        left: '202.5px'
+        top: '36px',
+        left: '177px'
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

There's no information while hovering over the graph in the app that can help verify what build/revision you're about to interact with.

# Solution

* Refactor `Tooltip` into `Tooltip` (`left`, `top` props) and `RelativeTooltip` (`relativeTo` prop)
* Use `RelativeTooltip` where `Tooltip` was used before
* Use `Tooltip` in `HoverOverlay` to show revision value and current hovered artifact

Fixes #12

# Examples
<img width="1392" alt="hovering the middle of the graph" src="https://user-images.githubusercontent.com/33297/76707310-50d81280-66ab-11ea-8b05-cade91a7f43a.png">
<img width="1392" alt="hovering top-left of the graph" src="https://user-images.githubusercontent.com/33297/76707312-53d30300-66ab-11ea-93ff-bcc652b0d5da.png">
<img width="1392" alt="hovering deltacell" src="https://user-images.githubusercontent.com/33297/76707313-546b9980-66ab-11ea-9d55-64048244fda5.png">


# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
