### PR TITLE
[docs] add instructions for deploying to heroku

### DIFF
--- a/docs/docs/guides/guides.md
+++ b/docs/docs/guides/guides.md
@@ -7,6 +7,7 @@ sidebar_label: Guides
 > This page is currently just a placeholder.
 > It is a jumping point for guides and ideas for doing more with Build Tracker. If you have ideas for more, please help by [contributing](contributing)!
 
+- [Deploy to Heroku](heroku)
 - [GitHub Actions](github-actions)
 - [Continuous Integration](advanced-ci)
 - [Contributing](contributing)

--- a/docs/docs/guides/heroku.md
+++ b/docs/docs/guides/heroku.md
@@ -1,0 +1,33 @@
+---
+id: heroku
+title: Deploy to Heroku
+sidebar_label: Deploy to Heroku
+---
+
+## Prerequisites
+
+This documentation assumes that you have an active Heroku account.
+
+## 1. Create a new repository from the template
+
+On GitHub, [create a new repository using the template](https://github.com/paularmstrong/build-tracker-heroku/generate) from [paularmstrong/build-tracker-heroku](https://github.com/paularmstrong/build-tracker-heroku).
+
+## 2. Update the `build-tracker.config.js` file
+
+This is the `@build-tracker/server` configuration. The most important thing to do here is to set up your [performance budgets](/docs/budgets). There are also [more options](/docs/packages/server#configuration) available that you may want to set as well. It is not recommended to change any of the presets other than the `artifacts` option.
+
+## 3. Deploy to Heroku
+
+If you are set up as a public GitHub repository, simply click the _Deploy to Heroku_ button at the top of the README.md file while viewing it on GitHub.
+
+If you are using a private repository, update the `README.md` link to use the `?template=` argument, replacing the repository `my-org/my-repository` in this string with the correct organization and repository path:
+
+```
+https://heroku.com/deploy?template=https://github.com/my-org/my-repository/tree/master
+```
+
+Once that URL is updated, you may click it any time.
+
+## 4. Configure on Heroku
+
+Follow the instructions provided on Heroku to deploy your Build Tracker application. Take special note that the `BT_URL` option must be provided with the same application name if you plan on using a herokuapp.com domain. If you are going to configure any other domain, enter that instead.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   docs: {
     'Getting Started': ['installation', 'budgets'],
-    Guides: ['guides/guides', 'guides/github-actions', 'guides/advanced-ci', 'guides/contributing'],
+    Guides: ['guides/guides', 'guides/heroku', 'guides/github-actions', 'guides/advanced-ci', 'guides/contributing'],
     Packages: [
       'packages/api-client',
       'packages/api-errors',


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

There are no easy "getting started" docs for deploying the server to a free service

# Solution

Created a github template: [paularmstrong/build-tracker-heroku](https://github.com/paularmstrong/build-tracker-heroku)
Added docs with instructions

Fixes #66

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
