### PR TITLE
[chore] add codecov to pushes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install
       - name: Tests
-        run: yarn test:ci
+        run: yarn test:ci --coverage
+      - name: Upload to codecov
+        uses: codecov/codecov-action@v1
 
   lint:
     name: Lint

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,4 +10,4 @@ coverage:
 comment:
   layout: 'reach,diff,flags,tree'
   behavior: default
-  require_changes: yes
+  require_changes: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,6 @@ coverage:
   range: '90...100'
 
 comment:
-  layout: 'reach,diff,flags,tree'
+  layout: 'diff,files'
   behavior: default
   require_changes: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  branch: next
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: '90...100'
+
+comment:
+  layout: 'reach,diff,flags,tree'
+  behavior: default
+  require_changes: yes


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Code coverage helps ensure fewer regressions in behavior.

# Solution

Add codecov

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
