### PR TITLE
fix(app): prevent extra horizontal padding on area graph

### DIFF
--- a/src/app/src/components/Graph/__tests__/index.test.tsx
+++ b/src/app/src/components/Graph/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import buildDataA from '@build-tracker/fixtures/builds-medium/30af629d1d4c9f2f19
 import buildDataB from '@build-tracker/fixtures/builds-medium/22abb6f829a07ca96ff56deeadf4d0e8fc2dbb04.json';
 import buildDataC from '@build-tracker/fixtures/builds-medium/243024909db66ac3c3e48d2ffe4015f049609834.json';
 import Comparator from '@build-tracker/comparator';
+import Graph from '../';
 import { GraphType } from '../../../store/types';
 import mockStore from '../../../store/mock';
 import { Provider } from 'react-redux';
@@ -14,7 +15,6 @@ import React from 'react';
 import StackedBar from '../StackedBar';
 import { View } from 'react-native';
 import { fireEvent, render } from 'react-native-testing-library';
-import Graph, { SVG } from '../';
 
 const builds = [
   new Build(buildDataA.meta, buildDataA.artifacts),
@@ -41,7 +41,8 @@ describe('Graph', () => {
       </Provider>
     );
     fireEvent(getByType(View), 'layout', { nativeEvent: { layout: { width: 400, height: 300 } } });
-    const svg = getByType(SVG);
+    // @ts-ignore this does work, actually
+    const svg = getByType('svg');
     expect(svg.props.width).toEqual(400);
     expect(svg.props.height).toEqual(300);
   });

--- a/src/app/src/components/Graph/index.tsx
+++ b/src/app/src/components/Graph/index.tsx
@@ -14,15 +14,9 @@ import XAxis from './XAxis';
 import YAxis from './YAxis';
 import { addComparedRevision, setHoveredArtifacts } from '../../store/actions';
 import { GraphType, State } from '../../store/types';
-import { LayoutChangeEvent, StyleSheet, unstable_createElement, View } from 'react-native';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { scaleBand, scaleLinear, scalePoint } from 'd3-scale';
 import { useDispatch, useSelector } from 'react-redux';
-
-export class SVG extends React.Component<{ height: number; width: number }> {
-  public render(): React.ReactElement {
-    return unstable_createElement('svg', this.props);
-  }
-}
 
 interface Props {
   comparator: State['comparator'];
@@ -55,8 +49,7 @@ const Graph = (props: Props): React.ReactElement => {
     return graphType === GraphType.AREA
       ? scalePoint()
           .range([0, width - Offset.LEFT - Offset.RIGHT])
-          .padding(0.05)
-          .round(true)
+          .padding(0.5)
           .domain(domain)
       : scaleBand()
           .rangeRound([0, width - Offset.LEFT - Offset.RIGHT])
@@ -83,14 +76,17 @@ const Graph = (props: Props): React.ReactElement => {
     return dataStack(comparator.builds);
   }, [activeArtifactNames, comparator, sizeKey]);
 
-  const handleLayout = (event: LayoutChangeEvent): void => {
-    const {
-      nativeEvent: {
-        layout: { height, width }
-      }
-    } = event;
-    setDimensions({ height, width });
-  };
+  const handleLayout = React.useCallback(
+    (event: LayoutChangeEvent): void => {
+      const {
+        nativeEvent: {
+          layout: { height, width }
+        }
+      } = event;
+      setDimensions({ height, width });
+    },
+    [setDimensions]
+  );
 
   const handleHoverArtifacts = React.useCallback(
     (artifacts: Array<string>): void => {
@@ -108,7 +104,7 @@ const Graph = (props: Props): React.ReactElement => {
 
   return (
     <View onLayout={handleLayout} style={styles.root}>
-      <SVG height={height} ref={svgRef} width={width}>
+      <svg height={height} ref={svgRef} width={width}>
         <g className="main" transform={`translate(${Offset.LEFT},${Offset.TOP})`}>
           {height && width ? (
             <>
@@ -151,7 +147,7 @@ const Graph = (props: Props): React.ReactElement => {
             </>
           ) : null}
         </g>
-      </SVG>
+      </svg>
     </View>
   );
 };


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

When using the Area style graph and a lot of builds, too much horizontal space can be given at the edges of the graph:
<img width="1392" alt="Screen Shot 2020-03-16 at 8 04 49 PM" src="https://user-images.githubusercontent.com/33297/76817903-69d2e780-67c1-11ea-8830-202adb7ab7ee.png">

# Solution

Removing the `round`ing from the `xScale` prevents D3 from wonky calculations.
<img width="1392" alt="Screen Shot 2020-03-16 at 8 05 22 PM" src="https://user-images.githubusercontent.com/33297/76817953-8c650080-67c1-11ea-8189-3edabb7f9332.png">


# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
