### PR TITLE
Correct `ApiReturn` type

### DIFF
--- a/src/api-client/src/modules/__tests__/upload-build.test.ts
+++ b/src/api-client/src/modules/__tests__/upload-build.test.ts
@@ -17,11 +17,8 @@ const build = {
 };
 
 const returnValue = {
-  build,
-  parentBuild: build,
-  json: {},
-  markdown: '',
-  csv: ''
+  comparatorData: '',
+  summary: []
 };
 
 describe('uploadBuild', () => {

--- a/src/api-client/src/modules/__tests__/upload-build.test.ts
+++ b/src/api-client/src/modules/__tests__/upload-build.test.ts
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
+import { ApiReturn } from '../config';
 import config from '@build-tracker/fixtures/cli-configs/rc/.build-trackerrc.js';
 import httpConfig from '@build-tracker/fixtures/cli-configs/rc/.build-tracker-http-rc.js';
 import nock from 'nock';
@@ -16,7 +17,7 @@ const build = {
   artifacts: []
 };
 
-const returnValue = {
+const returnValue: ApiReturn = {
   comparatorData: '',
   summary: []
 };

--- a/src/api-client/src/modules/config.ts
+++ b/src/api-client/src/modules/config.ts
@@ -1,21 +1,11 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import { ComparisonMatrix } from '@build-tracker/comparator';
 import cosmiconfig from 'cosmiconfig';
-import { Artifact, BuildMeta } from '@build-tracker/build';
-
-interface BuildJson {
-  meta: BuildMeta;
-  artifacts: Array<Artifact>;
-}
 
 export interface ApiReturn {
-  build: BuildJson;
-  parentBuild: BuildJson;
-  json: ComparisonMatrix;
-  markdown: string;
-  csv: string;
+  comparatorData: string;
+  summary: Array<string>;
 }
 
 export interface Config {

--- a/src/server/src/api/insert.ts
+++ b/src/server/src/api/insert.ts
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
+import { ApiReturn } from '@build-tracker/api-client/src/modules/config';
 import Build from '@build-tracker/build';
 import Comparator from '@build-tracker/comparator';
 import { Queries } from '../types';
@@ -65,10 +66,11 @@ export const insertBuild = (
           return onInserted(context.comparator).then(() => context);
         })
         .then(({ comparator }) => {
-          res.send({
+          const response: ApiReturn = {
             comparatorData: comparator.serialize(),
             summary: comparator.toSummary()
-          });
+          };
+          res.send(response);
         })
     )
     .catch(error => {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

The example at https://buildtracker.dev/docs/guides/advanced-ci/ fails to type check, because the `onCompare` parameter (`ApiReturn`) seems to be incorrect.

# Solution

<!--
Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better.

When trying to solve more solutions with Build Tracker, please keep in mind some of the following goals of the project:
* Be lightweight: small package sizes (single-digit KiBs, gzipped)
* Be easy: too many options in an API can become confusing
* Be clear: the intended purpose of every method should be as obvious as possible
* Is it easy to do this in "userland"? Would it be better off done there?
-->

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
