### PR TITLE
docs: Fix CLI docs link & specific applicationUrl

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -57,7 +57,7 @@ You will need, at a minimum, the `applicationUrl` string, and `artifacts` search
 
 ```js
 module.exports = {
-  applicationUrl: 'https://your-build-tracker-app.herokuapp.com', // The same as your server config `url`
+  applicationUrl: 'https://your-build-tracker-app.example.com', // The same as your server config `url`
   artifacts: ['dist/**/*.js'] // an Array of glob-style file paths
 };
 ```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -53,11 +53,11 @@ yarn add @build-tracker/api-client@latest
 
 Create a configuration file, `build-tracker.config.js`
 
-You will need, at a minimum, the `applicationUrl` string, and `artifacts` search locations set. For the full set of CLI options, refer to the [cli docs](cli).
+You will need, at a minimum, the `applicationUrl` string, and `artifacts` search locations set. For the full set of CLI options, refer to the [cli docs](packages/cli/).
 
 ```js
 module.exports = {
-  applicationUrl: 'https://your-build-tracker-app', // The same as your server config `url`
+  applicationUrl: 'https://your-build-tracker-app.herokuapp.com', // The same as your server config `url`
   artifacts: ['dist/**/*.js'] // an Array of glob-style file paths
 };
 ```


### PR DESCRIPTION

# Problem

two problems. 

one was a 404 of docs. easy.

other is was that i first tried `applicationUrl: 'https://lh-build-tracker.herokuapp.com/',`. It turns out that trailing slash leads to some unexpected results, where the "API" returns HTML and it all goes haywire. :)  I added a small console.log on the API response to see what was happening. Anyway, the fix seemed to be dropping the trailing slash.    I figure leaving it out here may help future users.  Up to you if you want a different fix :)


# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [X] 📖 Update relevant documentation
