### PR TITLE
fix(api): ensure output from api/api-client gives context

### DIFF
--- a/src/api-client/src/modules/__tests__/upload-build.test.ts
+++ b/src/api-client/src/modules/__tests__/upload-build.test.ts
@@ -57,13 +57,17 @@ describe('uploadBuild', () => {
   });
 
   test('if request failed, responds with error and does not invoke `onCompare`', async () => {
+    const logger = { log: jest.fn(), error: jest.fn() };
     const onCompareSpy = jest.spyOn(config, 'onCompare').mockImplementationOnce(() => Promise.resolve());
 
     nock(`${config.applicationUrl}/`)
       .post('/api/builds')
       .reply(500, { error: 'Something went wrong.' });
 
-    await expect(uploadBuild(config, build)).rejects.toStrictEqual(new Error('Something went wrong.'));
+    await expect(uploadBuild(config, build, undefined, logger)).rejects.toStrictEqual(
+      new Error('Something went wrong.')
+    );
+    expect(logger.error).toHaveBeenCalledWith('Something went wrong.');
     expect(onCompareSpy).not.toHaveBeenCalled();
   });
 
@@ -102,6 +106,6 @@ describe('uploadBuild', () => {
       .replyWithError(responseError);
 
     await expect(uploadBuild(config, build, undefined, logger)).rejects.toEqual(responseError);
-    expect(logger.error).toHaveBeenLastCalledWith(responseError.toString());
+    expect(logger.error).toHaveBeenCalledWith('Error: some error');
   });
 });

--- a/src/cli/src/commands/upload-build.ts
+++ b/src/cli/src/commands/upload-build.ts
@@ -22,12 +22,16 @@ export const handler = async (args: Args): Promise<void> => {
     skipDirtyCheck: args['skip-dirty-check']
   });
 
-  await uploadBuild(config, build, process.env.BT_API_AUTH_TOKEN, {
-    log: input => {
-      process.stdout.write(input);
-    },
-    error: input => {
-      process.stderr.write(input);
-    }
-  });
+  try {
+    await uploadBuild(config, build, process.env.BT_API_AUTH_TOKEN, {
+      log: input => {
+        process.stdout.write(`${input}\n`);
+      },
+      error: input => {
+        process.stderr.write(`${input}\n`);
+      }
+    });
+  } catch (e) {
+    process.exit(1);
+  }
 };

--- a/src/server/src/api/protected.ts
+++ b/src/server/src/api/protected.ts
@@ -14,12 +14,18 @@ export default function(req: Request, res: Response, next: NextFunction): void {
   }
 
   if (!authHeaderValue) {
-    res.status(401).send({ error: new AuthError(`${req.path} request x-bt-auth header`) });
+    const error = new AuthError(
+      `${
+        req.path
+      } requires the x-bt-auth header to be set. This API is secured with a token, ensure you set the same BT_API_AUTH_TOKEN variable before requesting again`
+    );
+    res.status(error.status).send({ error: error.message });
     return;
   }
 
   if (authHeaderValue !== authToken) {
-    res.status(401).send({ error: new AuthError('invalid auth token') });
+    const error = new AuthError('invalid x-bt-auth token header');
+    res.status(error.status).send({ error: error.message });
     return;
   }
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Errors from the api-client and cli are pretty vague. They do not indicate what went wrong and how to fix it.

# Solution

Include more context in the response for `AuthError`s. Update the api-client to properly log the error response string instead of `[object Object]`

Example: <img width="1023" alt="Screen Shot 2020-03-20 at 9 06 46 AM" src="https://user-images.githubusercontent.com/33297/77183032-f49a3780-6a8a-11ea-86af-5254fee7d2cf.png">

Fixes #176 
Fixes #177

cc @paulirish 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
