### PR TITLE
ci: update ci tsc config excludes

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "exclude": ["src/**/dist/**"]
+  "exclude": ["src/*/dist/**", "plugins/**/dist/**"]
 }


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem
The CI/test config for typescript is missing excludes for `dist` directories in the `plugins` workspaces

# Solution
Add the excludes

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
