### PR TITLE
include date in tooltip

### DIFF
--- a/src/app/src/components/Graph/HoverOverlay.tsx
+++ b/src/app/src/components/Graph/HoverOverlay.tsx
@@ -27,7 +27,7 @@ const handleMoveLine = memoize(
   (line, xPos): void => {
     select(line)
       .transition()
-      .duration(250)
+      .duration(50)
       .attr('x1', xPos)
       .attr('x2', xPos);
   }
@@ -116,8 +116,27 @@ const HoverOverlay = (props: Props): React.ReactElement => {
 
   const getTooltipText = React.useCallback((): string => {
     const revision = buildRevisionFromX(offsetX - Offset.LEFT);
-    return `Revision: ${formatSha(revision.value)}, Artifact: ${hoveredArtifact}`;
-  }, [buildRevisionFromX, hoveredArtifact, offsetX]);
+
+    const dataSeries = data.find(d => d.key === hoveredArtifact);
+    const build = dataSeries[revision.index].data;
+    const date = new Date(parseInt(`${build.meta.timestamp}000`, 10));
+    const formattedDate =
+      date
+        .toLocaleDateString('ja', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit'
+        })
+        .replace(/\//g, '-') +
+      ' ' +
+      date.toLocaleTimeString();
+
+    return `
+Revision: ${formatSha(revision.value)}
+Date: ${formattedDate}
+Artifact: ${hoveredArtifact}
+`.trim();
+  }, [buildRevisionFromX, data, hoveredArtifact, offsetX]);
 
   return (
     <g>

--- a/src/app/src/components/Graph/HoverOverlay.tsx
+++ b/src/app/src/components/Graph/HoverOverlay.tsx
@@ -118,10 +118,10 @@ const HoverOverlay = (props: Props): React.ReactElement => {
     const revision = buildRevisionFromX(offsetX - Offset.LEFT);
 
     const dataSeries = data.find(d => d.key === hoveredArtifact);
-    const build = dataSeries[revision.index].data;
-    const date = new Date(parseInt(`${build.meta.timestamp}000`, 10));
+    const buildDate = dataSeries[revision.index].data.timestamp;
     const formattedDate =
-      date
+      // Output date as YYYY-MM-DD
+      buildDate
         .toLocaleDateString('ja', {
           year: 'numeric',
           month: '2-digit',
@@ -129,7 +129,7 @@ const HoverOverlay = (props: Props): React.ReactElement => {
         })
         .replace(/\//g, '-') +
       ' ' +
-      date.toLocaleTimeString();
+      buildDate.toLocaleTimeString();
 
     return `
 Revision: ${formatSha(revision.value)}

--- a/src/app/src/components/Tooltip.tsx
+++ b/src/app/src/components/Tooltip.tsx
@@ -90,8 +90,7 @@ const styles = StyleSheet.create({
   },
   text: {
     color: Theme.TextColor.Gray50,
-    fontSize: Theme.FontSize.Xsmall,
-    textAlign: 'center'
+    fontSize: Theme.FontSize.Xsmall
   }
 });
 


### PR DESCRIPTION

# Problem

When using buildtracker I had a hard time understanding where I was in the X axis.


# Solution

I added the date of the build into the tooltip.

![image](https://user-images.githubusercontent.com/39191/77214751-b6723780-6acd-11ea-889a-f3d5403e6722.png)

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation


I didn't write a test yet but wanted to get your early feedback on this. :)

----------

Oh.. and in a driveby I also changed the 250ms transition duration of the hoverline. It was distractingly slow and I though the app was being janky (it def isn't :). With 50ms, hovering feels far more responsive.