### PR TITLE
feat(app): add modal dialogs to comparison table

### DIFF
--- a/src/app/src/components/ComparisonTable/TotalCell.tsx
+++ b/src/app/src/components/ComparisonTable/TotalCell.tsx
@@ -2,10 +2,13 @@
  * Copyright (c) 2019 Paul Armstrong
  */
 import { TotalCell as Cell } from '@build-tracker/comparator';
+import CloseIcon from '../../icons/Close';
 import { formatBytes } from '@build-tracker/formatting';
 import React from 'react';
-import { Td } from './../Table';
-import { StyleProp, Text, ViewStyle } from 'react-native';
+import RelativeModal from '../RelativeModal';
+import TabularMetadata from '../TabularMetadata';
+import { Td } from '../Table';
+import { StyleProp, Text, TouchableOpacity, ViewStyle } from 'react-native';
 
 interface Props {
   cell: Cell;
@@ -17,7 +20,37 @@ export const TotalCell = (props: Props): React.ReactElement => {
   const { cell, sizeKey, style } = props;
   const value = cell.sizes[sizeKey];
   const text = value === 0 ? '' : formatBytes(value);
-  return <Td style={style}>{text ? <Text>{text}</Text> : null}</Td>;
+
+  const cellRef = React.useRef();
+  const [dialogVisible, setDialogVisible] = React.useState(false);
+
+  const handlePress = React.useCallback((): void => {
+    setDialogVisible(true);
+  }, [setDialogVisible]);
+
+  const handleDismissDialog = React.useCallback((): void => {
+    setDialogVisible(false);
+  }, [setDialogVisible]);
+
+  const tableData = Object.keys(cell.sizes).reduce((memo: Array<[string, string]>, metaKey: string): Array<
+    [string, string]
+  > => {
+    memo.push([metaKey, formatBytes(cell.sizes[metaKey])]);
+    return memo;
+  }, []);
+
+  return (
+    <Td style={style}>
+      <TouchableOpacity onPress={handlePress} ref={cellRef}>
+        {text ? <Text>{text}</Text> : null}
+      </TouchableOpacity>
+      {dialogVisible ? (
+        <RelativeModal onDismiss={handleDismissDialog} portalRootID="menuPortal" relativeTo={cellRef}>
+          <TabularMetadata data={tableData} icon={CloseIcon} onClose={handleDismissDialog} title={cell.name} />
+        </RelativeModal>
+      ) : null}
+    </Td>
+  );
 };
 
 export default React.memo(TotalCell);

--- a/src/app/src/components/ComparisonTable/__tests__/TotalCell.test.tsx
+++ b/src/app/src/components/ComparisonTable/__tests__/TotalCell.test.tsx
@@ -3,9 +3,9 @@
  */
 import { CellType } from '@build-tracker/comparator';
 import React from 'react';
-import { render } from 'react-native-testing-library';
 import { Text } from 'react-native';
 import { TotalCell } from '../TotalCell';
+import { fireEvent, render } from 'react-native-testing-library';
 
 describe('TotalCell', () => {
   test('Displays a formatted value', () => {
@@ -20,5 +20,28 @@ describe('TotalCell', () => {
       <TotalCell cell={{ type: CellType.TOTAL, name: 'tacos', sizes: { stat: 0 } }} sizeKey="stat" />
     );
     expect(queryAllByType(Text)).toHaveLength(0);
+  });
+
+  describe('modal dialog', () => {
+    test('shows and hides modal dialog when closed', () => {
+      const { getByProps, getByText } = render(
+        <TotalCell cell={{ type: CellType.TOTAL, name: 'tacos', sizes: { stat: 4300, gzip: 2400 } }} sizeKey="stat" />
+      );
+      fireEvent.press(getByText('4.2 KiB'));
+      expect(getByProps({ role: 'dialog' })).not.toBeNull();
+      fireEvent.press(getByProps({ role: 'button', 'aria-label': 'Close' }));
+      expect(() => getByProps({ role: 'dialog' })).toThrow();
+    });
+
+    test('renders all stat size information in a modal dialog', () => {
+      const { getByText, queryAllByText } = render(
+        <TotalCell cell={{ type: CellType.TOTAL, name: 'tacos', sizes: { stat: 4300, gzip: 2400 } }} sizeKey="stat" />
+      );
+      fireEvent.press(getByText('4.2 KiB'));
+      expect(queryAllByText('gzip')).toHaveLength(1);
+      expect(queryAllByText('2.34 KiB')).toHaveLength(1);
+      expect(queryAllByText('stat')).toHaveLength(1);
+      expect(queryAllByText('4.2 KiB')).toHaveLength(2);
+    });
   });
 });

--- a/src/app/src/components/RelativeModal.tsx
+++ b/src/app/src/components/RelativeModal.tsx
@@ -61,7 +61,7 @@ const Menu = (props: Props): React.ReactElement => {
         testID="overlay"
       />
       <View
-        accessibilityRole={accessibilityRole}
+        accessibilityRole={accessibilityRole || 'dialog'}
         ref={ref}
         style={[
           styles.root,

--- a/src/app/src/components/TabularMetadata.tsx
+++ b/src/app/src/components/TabularMetadata.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import * as Theme from '../theme';
+import { BuildMetaItem } from '@build-tracker/build';
+import Button from './Button';
+import CloseIcon from '../icons/Close';
+import React from 'react';
+import TextLink from './TextLink';
+import { StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native';
+import { Table, Tbody, Td, Th, Tr } from './Table';
+
+interface Props {
+  closeButtonLabel?: string;
+  data: Array<[string, BuildMetaItem]>;
+  footer?: React.ReactElement;
+  icon?: React.ComponentType<{ style?: StyleProp<TextStyle> }>;
+  onClose?: () => void;
+  title: string;
+}
+
+function getMetaValue(val: string | BuildMetaItem): string {
+  // @ts-ignore
+  return typeof val === 'object' && val.hasOwnProperty('value') ? val.value : val;
+}
+
+function getMetaUrl(val: string | BuildMetaItem): string | undefined {
+  // @ts-ignore
+  return typeof val === 'object' && val.hasOwnProperty('url') ? val.url : undefined;
+}
+
+const TabularMetadata = (props: Props): React.ReactElement => {
+  const { closeButtonLabel, data, footer, icon, onClose, title } = props;
+
+  const handleClose = React.useCallback(() => {
+    onClose && onClose();
+  }, [onClose]);
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.header}>
+        <Text style={styles.headerText}>{title}</Text>
+        <Button icon={icon || CloseIcon} iconOnly onPress={handleClose} title={closeButtonLabel || 'Close'} />
+      </View>
+      <Table>
+        <Tbody>
+          {data.map(([key, dataValue]) => {
+            const value = getMetaValue(dataValue);
+            const url = getMetaUrl(dataValue);
+            return (
+              <Tr key={key}>
+                <Th>
+                  <Text>{key}</Text>
+                </Th>
+                <Td style={styles.infoCell}>{url ? <TextLink href={url} text={value} /> : <Text>{value}</Text>}</Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
+      {footer ? <View style={styles.footer}>{footer}</View> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    paddingVertical: Theme.Spacing.Small,
+    paddingHorizontal: Theme.Spacing.Small,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerText: {
+    fontWeight: Theme.FontWeight.Bold,
+    fontSize: Theme.FontSize.Normal,
+  },
+  infoCell: {
+    textAlign: 'left',
+  },
+  footer: {
+    alignItems: 'flex-start',
+    paddingTop: Theme.Spacing.Normal,
+  },
+});
+
+export default TabularMetadata;

--- a/src/app/src/components/__tests__/BuildInfo.test.tsx
+++ b/src/app/src/components/__tests__/BuildInfo.test.tsx
@@ -8,7 +8,6 @@ import Comparator from '@build-tracker/comparator';
 import mockStore from '../../store/mock';
 import { Provider } from 'react-redux';
 import React from 'react';
-import TextLink from '../TextLink';
 import { fireEvent, render } from 'react-native-testing-library';
 
 const build = new Build({ branch: 'master', revision: '1234565', parentRevision: 'abcdef', timestamp: 123 }, []);
@@ -23,54 +22,6 @@ describe('BuildInfo', () => {
     );
     fireEvent.press(getByProps({ title: 'Collapse details' }));
     expect(focusRevisionSpy).toHaveBeenCalledWith(undefined);
-  });
-
-  test('renders a text link if the revision has a URL', () => {
-    const buildA = new Build(
-      {
-        branch: 'master',
-        revision: {
-          value: '123456',
-          url: 'https://github.com/paularmstrong/build-tracker/commit/123456',
-        },
-        parentRevision: 'abcdef',
-        timestamp: 123,
-      },
-      []
-    );
-    const { getByType } = render(
-      <Provider store={mockStore({ comparator: new Comparator({ builds: [buildA] }) })}>
-        <BuildInfo focusedRevision="123456" />
-      </Provider>
-    );
-    expect(getByType(TextLink).props).toMatchObject({
-      href: 'https://github.com/paularmstrong/build-tracker/commit/123456',
-      text: '123456',
-    });
-  });
-
-  test('renders a text link for other keys that have a URL', () => {
-    const buildA = new Build(
-      {
-        branch: 'master',
-        revision: '123456',
-        parentRevision: {
-          value: 'abcdef',
-          url: 'https://github.com/paularmstrong/build-tracker/commit/abcdef',
-        },
-        timestamp: 123,
-      },
-      []
-    );
-    const { getByType } = render(
-      <Provider store={mockStore({ comparator: new Comparator({ builds: [buildA] }) })}>
-        <BuildInfo focusedRevision="123456" />
-      </Provider>
-    );
-    expect(getByType(TextLink).props).toMatchObject({
-      href: 'https://github.com/paularmstrong/build-tracker/commit/abcdef',
-      text: 'abcdef',
-    });
   });
 
   test('removes the build focus on button press', () => {

--- a/src/app/src/components/__tests__/TabularMetadata.test.tsx
+++ b/src/app/src/components/__tests__/TabularMetadata.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import React from 'react';
+import TabularMetadata from '../TabularMetadata';
+import TextLink from '../TextLink';
+import { View } from 'react-native';
+import { fireEvent, render } from 'react-native-testing-library';
+
+describe('TabularMetadata', () => {
+  describe('header', () => {
+    test('renders a header with title and button', () => {
+      const { getByText } = render(<TabularMetadata data={[]} title="Tacos" />);
+      expect(getByText('Tacos')).not.toBeNull();
+    });
+
+    test('on button press, calls onClose method', () => {
+      const handleClose = jest.fn();
+      const { getByProps } = render(<TabularMetadata data={[]} onClose={handleClose} title="Tacos" />);
+      fireEvent.press(getByProps({ role: 'button', 'aria-label': 'Close' }));
+      expect(handleClose).toHaveBeenCalled();
+    });
+
+    test('does not require onClose method', () => {
+      const { getByProps } = render(<TabularMetadata data={[]} title="Tacos" />);
+      expect(() => fireEvent.press(getByProps({ role: 'button', 'aria-label': 'Close' }))).not.toThrow();
+    });
+  });
+
+  describe('table', () => {
+    test('renders rows with data', () => {
+      const { getByText } = render(
+        <TabularMetadata
+          data={[
+            ['special', 'tacos'],
+            ['regular', 'burritos'],
+          ]}
+          title="Tacos"
+        />
+      );
+      expect(getByText('special')).not.toBeNull();
+      expect(getByText('tacos')).not.toBeNull();
+      expect(getByText('regular')).not.toBeNull();
+      expect(getByText('burritos')).not.toBeNull();
+    });
+
+    test('renders links when URLs are provided', () => {
+      const { getByType } = render(
+        <TabularMetadata data={[['special', { value: 'tacos', url: '/tacos-url' }]]} title="Tacos" />
+      );
+      expect(getByType(TextLink).props).toMatchObject({
+        href: '/tacos-url',
+        text: 'tacos',
+      });
+    });
+  });
+
+  describe('footer', () => {
+    test('renders footer when provided', () => {
+      const footer = <View testID="footer" />;
+      const { getByTestId } = render(<TabularMetadata data={[]} footer={footer} title="Tacos" />);
+      expect(getByTestId('footer')).not.toBeNull();
+    });
+  });
+});

--- a/typings/react-native/index.d.ts
+++ b/typings/react-native/index.d.ts
@@ -443,6 +443,7 @@ export interface Insets {
  * @see React.DOMAtributes
  */
 export interface Touchable {
+  autoFocus?: boolean;
   onTouchStart?: (event: GestureResponderEvent) => void;
   onTouchMove?: (event: GestureResponderEvent) => void;
   onTouchEnd?: (event: GestureResponderEvent) => void;
@@ -695,7 +696,8 @@ export interface TransformsStyle {
     | TranslateXTransform
     | TranslateYTransform
     | SkewXTransform
-    | SkewYTransform)[];
+    | SkewYTransform
+  )[];
   transformMatrix?: Array<number>;
   rotation?: number;
   scaleX?: number;
@@ -1581,6 +1583,7 @@ export type AccessibilityRole =
   | 'button'
   | 'checkbox'
   | 'combobox'
+  | 'dialog'
   | 'header'
   | 'image'
   | 'imagebutton'
@@ -1643,6 +1646,8 @@ export interface ViewProps extends GestureResponderHandlers, Touchable, Accessib
   hitSlop?: Insets;
 
   href?: string;
+
+  onKeyPress?: (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => void;
 
   /**
    * Invoked on mount and layout changes with


### PR DESCRIPTION
# Problem

Sometimes when I'm digging into the table, I want to see more information about the artifact in the build or the delta (like all sizeKey changes, etc). There's currently no short way of doing that.

# Solution

On press (click), a modal window could open that nicely formats the full `Artifact` or `ArtifactDelta` object (depending on which cell type).

<img width="526" alt="Screen Shot 2020-03-28 at 12 21 08 PM" src="https://user-images.githubusercontent.com/33297/77831820-a4585080-70ee-11ea-930c-453b80805b3f.png">
<img width="373" alt="Screen Shot 2020-03-28 at 12 21 01 PM" src="https://user-images.githubusercontent.com/33297/77831821-a5897d80-70ee-11ea-88b7-4a764c28c23d.png">

Closes #183 

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
