### PR TITLE
docs: fix readme typo in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All documentation can be found at [buildtracker.dev](https://buildtracker.dev).
 
 All project participants are expected to adhere to the repository's Code of Conduct. Please read [the full text](https://github.com/paularmstrong/build-tracker/blob/master/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
-### [Contributing Guide](https://build-tracker.dev/docs/guides/contributing)
+### [Contributing Guide](https://buildtracker.dev/docs/guides/contributing)
 
 Read the contributing guide to learn about the development process, how to propose fixes and improvements, and how to build and test your changes.
 


### PR DESCRIPTION
# Problem

typo in the readme

# Solution

i fixed it

# TODO

- [ ] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
