### PR TITLE
chore(api-client): add child process invocation command to error output

### DIFF
--- a/src/api-client/src/modules/spawn.ts
+++ b/src/api-client/src/modules/spawn.ts
@@ -37,7 +37,8 @@ export default function spawn(command: string, args?: ReadonlyArray<string>, opt
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        return reject({ code, stderr: Buffer.concat(stderr).toString(), errors });
+        const invocation = `${command} ${(args || []).join(' ')}`;
+        return reject({ code, stderr: Buffer.concat(stderr).toString(), errors, invocation });
       }
       resolve(Buffer.concat(stdout));
     });


### PR DESCRIPTION
# Problem

## Problem

Sometimes buildtracker fails randomly. Example: https://github.com/GoogleChrome/lighthouse/runs/1130093961?check_suite_focus=true#step:19:25

![image](https://user-images.githubusercontent.com/39191/81232088-199a2980-8fa9-11ea-86ac-3f0523a05664.png)

since we have no idea what command triggered a nonzero exit code, it's a bit hard to debug.

# Solution

since the error object that spawn() rejects with already has a few things, and is logged out to stderr... i figure why not.

fixes #200

# TODO

- [X] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [X] 📖 Update relevant documentation
