### PR TITLE
feat(comparator cli): allow comparisons even if size keys do not match

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 12.x
       - run: npm install -g yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/src/cli/src/commands/__tests__/create-build.test.ts
+++ b/src/cli/src/commands/__tests__/create-build.test.ts
@@ -47,7 +47,7 @@ describe('create-build', () => {
 
     test('writes the artifact stats to stdout', async () => {
       await expect(Command.handler({ config, out: true, 'skip-dirty-check': true })).resolves.toBeUndefined();
-      expect(writeSpy).toHaveBeenCalledWith(expect.stringMatching('"parentRevision": "7654321",'));
+      expect(writeSpy).toHaveBeenCalledWith(expect.stringMatching('"parentRevision": "'));
     });
 
     test('converts JSON string-encoded metadata', async () => {

--- a/src/comparator/src/BuildDelta.ts
+++ b/src/comparator/src/BuildDelta.ts
@@ -50,12 +50,6 @@ export default class BuildDelta<M extends BuildMeta = BuildMeta> {
       this._prevBuild.artifactSizes.forEach((key) => {
         this._sizeKeys.add(key);
       });
-      if (
-        this._sizeKeys.size !== this._baseBuild.artifactSizes.length ||
-        this._sizeKeys.size !== this._prevBuild.artifactSizes.length
-      ) {
-        throw new Error('Size keys do not match between builds');
-      }
     }
 
     return Array.from(this._sizeKeys);

--- a/src/comparator/src/__tests__/BuildDelta.test.ts
+++ b/src/comparator/src/__tests__/BuildDelta.test.ts
@@ -57,22 +57,6 @@ describe('BuildDelta', () => {
       const bd = new BuildDelta(buildA, buildB);
       expect(bd.artifactSizes).toEqual(['stat', 'gzip']);
     });
-
-    test('throws an error if builds do not have same artifact size keys', () => {
-      const bd = new BuildDelta(
-        buildA,
-        new Build(
-          {
-            branch: 'master',
-            revision: { value: '123', url: 'https://build-tracker.local' },
-            parentRevision: 'abc',
-            timestamp: Date.now(),
-          },
-          [{ name: 'tacos', hash: 'abc', sizes: {} }]
-        )
-      );
-      expect(() => bd.artifactSizes).toThrow();
-    });
   });
 
   describe('artifactNames', () => {

--- a/src/comparator/src/index.ts
+++ b/src/comparator/src/index.ts
@@ -205,7 +205,7 @@ export default class BuildComparator {
         if (buildA.getMetaValue('parentRevision') === buildB.getMetaValue('revision')) {
           return 1;
         }
-        if (buildB.getMetaValue('revision') === buildA.getMetaValue('parentRevision')) {
+        if (buildA.getMetaValue('revision') === buildB.getMetaValue('parentRevision')) {
           return -1;
         }
         return 0;
@@ -286,10 +286,6 @@ export default class BuildComparator {
           });
         });
       });
-
-      if (allSizeKeys.size !== this._sizeKeys.length || !this._sizeKeys.every((key) => allSizeKeys.has(key))) {
-        throw new Error('builds provided do not have same size keys for artifacts');
-      }
     }
     return this._sizeKeys;
   }


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Build Tracker project!
-->

# Problem

Switching from Node 10 to Node 12 produces an issue that suddenly `brotli` will be included in available `sizeKeys` for builds. This causes various things to throw errors because they're hardcoded to not allow a change in the `sizeKeys`

# Solution

This manual throwing seems unnecessary. By removing these checks, we can allow comparisons with the given keys, the result will just cause the comparison to show `0`s for the build missing that size key.

Also updated CI to node 12

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [x] 📖 Update relevant documentation
