### PR TITLE
[WIP] Get build

### DIFF
--- a/config/api-config.js
+++ b/config/api-config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  applicationUrl: 'http://localhost:3000',
+  artifacts: ['src/*/dist/**/*', 'plugins/*/dist/**/*'],
+};

--- a/src/api-client/src/index.ts
+++ b/src/api-client/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { default as createBuild } from './modules/create-build';
+export { default as getBuild } from './modules/get-build';
 export { Config, default as getConfig } from './modules/config';
 export { default as statArtifacts } from './modules/stat-artifacts';
 export { default as uploadBuild } from './modules/upload-build';

--- a/src/api-client/src/modules/__tests__/get-build.test.ts
+++ b/src/api-client/src/modules/__tests__/get-build.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import config from '@build-tracker/fixtures/cli-configs/rc/.build-trackerrc.js';
+const fakeBuild = require('@build-tracker/fixtures/builds-medium/1bf811ec249c2b13a314e127312b2d760f6658e2.json');
+import getBuild from '../get-build';
+import nock from 'nock';
+import { NotFoundError } from '@build-tracker/api-errors';
+
+describe('getBuild', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('exist', () => {
+    expect(getBuild).toBeDefined();
+  });
+
+  test('when found returns build', async () => {
+    nock(`${config.applicationUrl}/`).get('/api/builds/1bf811ec249c2b13a314e127312b2d760f6658e2').reply(200, fakeBuild);
+
+    await expect(getBuild(config, '1bf811ec249c2b13a314e127312b2d760f6658e2')).resolves.toMatchObject(fakeBuild);
+  });
+
+  test('when missing', async () => {
+    nock(`${config.applicationUrl}/`).get('/api/builds/blah').reply(404, new NotFoundError());
+
+    await expect(getBuild(config, 'blah')).rejects.toThrow(Error);
+  });
+});

--- a/src/api-client/src/modules/__tests__/get-build.test.ts
+++ b/src/api-client/src/modules/__tests__/get-build.test.ts
@@ -17,13 +17,13 @@ describe('getBuild', () => {
   });
 
   test('when found returns build', async () => {
-    nock(`${config.applicationUrl}/`).get('/api/builds/1bf811ec249c2b13a314e127312b2d760f6658e2').reply(200, fakeBuild);
+    nock(`${config.applicationUrl}/`).get('/api/build/1bf811ec249c2b13a314e127312b2d760f6658e2').reply(200, fakeBuild);
 
     await expect(getBuild(config, '1bf811ec249c2b13a314e127312b2d760f6658e2')).resolves.toMatchObject(fakeBuild);
   });
 
   test('when missing', async () => {
-    nock(`${config.applicationUrl}/`).get('/api/builds/blah').reply(404, new NotFoundError());
+    nock(`${config.applicationUrl}/`).get('/api/build/blah').reply(404, new NotFoundError());
 
     await expect(getBuild(config, 'blah')).rejects.toThrow(Error);
   });

--- a/src/api-client/src/modules/get-build.ts
+++ b/src/api-client/src/modules/get-build.ts
@@ -21,7 +21,7 @@ export default async function getBuild(
 ): Promise<Build> {
   const { applicationUrl } = config;
   // Call through to api/build/:revision
-  const url = new URL(`${applicationUrl}/api/builds/${revision}`);
+  const url = new URL(`${applicationUrl}/api/build/${revision}`);
   const httpProtocol = applicationUrl.startsWith('https:') ? https : http;
   const requestOptions = {
     host: url.hostname.replace(`${httpProtocol}//`, ''),

--- a/src/api-client/src/modules/get-build.ts
+++ b/src/api-client/src/modules/get-build.ts
@@ -1,0 +1,65 @@
+// eslint-disable-next-line header/header
+import Build from '@build-tracker/build';
+import { BuildMetaItem } from '@build-tracker/build';
+import { Config } from './config';
+import http from 'http';
+import https from 'https';
+
+export interface Logger {
+  log: (input: string) => void;
+  error: (input: string) => void;
+}
+
+const noop = (): void => {};
+
+export default async function getBuild(
+  config: Config,
+  revision: BuildMetaItem,
+  logger: Logger = { log: noop, error: noop }
+): Promise<Build> {
+  const { applicationUrl } = config;
+
+  // Call through to api/build/:revision
+  const url = new URL(`${applicationUrl}/api/builds/${revision}`);
+  const httpProtocol = applicationUrl.startsWith('https:') ? https : http;
+  const requestOptions = {
+    host: url.hostname.replace(`${httpProtocol}//`, ''),
+    port: url.port,
+    path: url.pathname,
+    method: 'GET',
+    headers: {
+      'content-type': 'application/json',
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = httpProtocol.request(requestOptions, (res: http.IncomingMessage) => {
+      const output = [];
+      res.setEncoding('utf8');
+
+      res.on('data', (data) => {
+        output.push(typeof data === 'string' ? data : data.toString());
+      });
+
+      res.on('end', async () => {
+        const response = JSON.parse(output.join(''));
+        if (res.statusCode >= 400) {
+          logger.error(response.error);
+          reject(new Error(response.error));
+          return;
+        }
+
+        const successResponse = Build.fromJSON(response);
+        logger.log(JSON.stringify(successResponse));
+        resolve(successResponse);
+      });
+    });
+
+    req.on('error', (error: Error) => {
+      logger.error(error.toString());
+      reject(error);
+    });
+
+    req.end();
+  });
+}

--- a/src/api-client/src/modules/get-build.ts
+++ b/src/api-client/src/modules/get-build.ts
@@ -1,4 +1,6 @@
-// eslint-disable-next-line header/header
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
 import Build from '@build-tracker/build';
 import { BuildMetaItem } from '@build-tracker/build';
 import { Config } from './config';

--- a/src/api-client/src/modules/get-build.ts
+++ b/src/api-client/src/modules/get-build.ts
@@ -18,7 +18,6 @@ export default async function getBuild(
   logger: Logger = { log: noop, error: noop }
 ): Promise<Build> {
   const { applicationUrl } = config;
-
   // Call through to api/build/:revision
   const url = new URL(`${applicationUrl}/api/builds/${revision}`);
   const httpProtocol = applicationUrl.startsWith('https:') ? https : http;

--- a/src/cli/src/commands/get-build.ts
+++ b/src/cli/src/commands/get-build.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 Paul Armstrong
+ */
+import { Argv } from 'yargs';
+import { getBuild, getConfig } from '@build-tracker/api-client';
+
+export const command = 'get-build';
+
+export const description = 'Retrieve a build by revision';
+
+export interface Args {
+  revision: string;
+  config?: string;
+  out: boolean;
+}
+
+const group = 'Retrieve a build';
+
+export const getBuildOptions = (yargs): Argv<Args> =>
+  yargs
+    .option('revision', {
+      alias: 'r',
+      description: 'Get the build using revision',
+      group,
+      type: 'string',
+    })
+    .option('config', {
+      alias: 'c',
+      description: 'Override path to the build-tracker CLI config file',
+      group,
+      normalize: true,
+    });
+
+export const builder = (yargs): Argv<Args> =>
+  getBuildOptions(yargs).usage(`Usage: $0 ${command}`).option('out', {
+    alias: 'o',
+    default: true,
+    description: 'Write the build to stdout',
+    group,
+    type: 'boolean',
+  });
+
+export const handler = async (args: Args): Promise<void> => {
+  const config = await getConfig(args.config);
+  const { revision } = args;
+  const build = await getBuild(config, revision);
+
+  if (args.out) {
+    process.stdout.write(JSON.stringify(build, null, 2));
+  }
+};


### PR DESCRIPTION
# Problem
#210  

We need a method to check if a build exists, in order to avoid e.g. re-uploading builds for comparison in CI jobs. If a build has already been uploaded, no need to do so again. This will also avoid issues relating to duplicate primary keys when rebuilding.

# Solution

This is totally WIP but here I'm adding a method that should simply call through to the [server:read method](https://github.com/paularmstrong/build-tracker/blob/master/src/server/src/api/index.ts#L21) for checking builds.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [x] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc:ci`)
- [ ] 📖 Update relevant documentation
- [x] 🕵️‍♀️ Check relevant internals are being called by method
- [x] 💻 Update CLI to include `get-build` method
