### PR TITLE
chore: Upgrade cosmiconfig to ^7.0.0

### DIFF
--- a/src/api-client/package.json
+++ b/src/api-client/package.json
@@ -19,12 +19,11 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@types/cosmiconfig": "^5.0.3",
     "@types/glob": "^7.1.1",
     "@types/node": "^11.10.4",
     "@types/yargs": "^15.0.0",
     "brotli-size": "^4.0.0",
-    "cosmiconfig": "^5.1.0",
+    "cosmiconfig": "^7.0.0",
     "glob": "^7.1.3",
     "gzip-size": "^5.0.0",
     "path-to-regexp": "3.0.0",

--- a/src/api-client/src/modules/config.ts
+++ b/src/api-client/src/modules/config.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019 Paul Armstrong
  */
-import cosmiconfig from 'cosmiconfig';
+import { cosmiconfig } from 'cosmiconfig';
 
 export interface ApiReturn {
   comparatorData: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,13 +3060,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cosmiconfig@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz#880644bb155d4038d3b752159684b777b0a159dd"
-  integrity sha512-HgTGG7X5y9pLl3pixeo2XtDEFD8rq2EuH+S4mK6teCnAwWMucQl6v1D43hI4Uw1VJh6nu59lxLkqXHRl4uwThA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/d3-axis@^1.0.12":
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-1.0.12.tgz#8c124edfcc02f3b3a9cdaa2a28b8a20341401799"
@@ -5831,6 +5824,17 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -17776,6 +17780,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
# Problem
`cosmiconfig` is 2 major versions out-of-date.

# Solution
Update `cosmiconfig` to `^7.0.0`. `cosmiconfig` is now written in TypeScript so `@types/cosmiconfig` is no longer necessary; `cosmiconfig` is also now a named export rather than the default export.

# TODO

- [x] 🤓 Add & update tests (always try to _increase_ test coverage)
- [ ] 🔬 Ensure CI is passing (`yarn lint:ci`, `yarn test`, `yarn tsc`)
- [x] 📖 Update relevant documentation
